### PR TITLE
Use 'util' instead of 'sys' to squash 0.6.x warning 

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,5 @@
 // Dependencies
-var Sys = require('sys'),
+var Sys = require('util'),
     File = require('fs'),
     Yaml = require('yaml'),
     Coffee = require('coffee-script'),


### PR DESCRIPTION
(it's been called 'util.js' since 0.2.x).
