### PR TITLE
Take people to latest docs straight away

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./lib/config.js",
   "description": "Configuration control for production node deployments",
   "author": "Loren West <open_source@lorenwest.com>",
-  "homepage": "http://lorenwest.github.com/node-config/",
+  "homepage": "http://lorenwest.github.com/node-config/latest/index.html",
   "directories": {"lib": "./lib", "config": "./config", "test": "./test"},
   "dependencies": {
     "yaml" : "0.2.x",


### PR DESCRIPTION
Currently it sends them to this intermediate page: http://lorenwest.github.com/node-config/. In most cases, people are probably just looking for the latest docs/github page.
