### PR TITLE
Put optional deps under optionalDeps, test deps under devDeps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "homepage": "http://lorenwest.github.com/node-config/",
   "directories": {"lib": "./lib", "config": "./config", "test": "./test"},
   "dependencies": {
+  },
+  "optionalDependencies": {
     "js-yaml" : "0.3.x",
     "coffee-script" : ">=1.2.0",
-    "vows" : ">=0.5.13"
-  },
+  }
   "devDependencies": {
+    "vows" : ">=0.5.13"
   },
   "engines": {"node": ">0.4.x"},
   "scripts": {


### PR DESCRIPTION
From https://npmjs.org/doc/json.html:
## devDependencies

If someone is planning on downloading and using your module in their program, then they probably don't want or need to download and build the external test or documentation framework that you use.

In this case, it's best to list these additional items in a devDependencies hash.

These things will be installed whenever the --dev configuration flag is set. This flag is set automatically when doing npm link, and can be managed like any other npm configuration param. See config(1) for more on the topic.
## optionalDependencies

If a dependency can be used, but you would like npm to proceed if it cannot be found or fails to install, then you may put it in the optionalDependencies hash. This is a map of package name to version or url, just like the dependencies hash. The difference is that failure is tolerated.

It is still your program's responsibility to handle the lack of the dependency.
