### PR TITLE
Oops, put the comma on the wrong place.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "optionalDependencies": {
     "js-yaml" : "0.3.x",
-    "coffee-script" : ">=1.2.0",
-  }
+    "coffee-script" : ">=1.2.0"
+  },
   "devDependencies": {
     "vows" : ">=0.5.13"
   },


### PR DESCRIPTION
I put the comma on the wrong line, and broke the install in the previous commit. Apparently, npm ls doesn't read package.json! But npm install fails.
