### PR TITLE
HOSTNAME and HOST precedence

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -578,10 +578,14 @@ Config.prototype._loadFileConfigs = function() {
   // Determine the host name from the OS module, $HOST, or $HOSTNAME
   // Remove any . appendages, and default to null if not set
   try {
-    var OS = require('os');
-    var hostName = OS.hostname();
+    var hostName = process.env.HOST || process.env.HOSTNAME;
+   
+    if (!hostName) {
+        var OS = require('os');
+        hostName = OS.hostname();
+    }
   } catch (e) {
-    hostName = process.env.HOST || process.env.HOSTNAME;
+    hostName = '';
   }
   hostName = hostName ? hostName.split('.')[0] : null;
 


### PR DESCRIPTION
The HOSTNAME and HOST ENV variables now take precedence over OS.hostname()
