### PR TITLE
Prevent call of Config.prototype._diffDeep with an undefined argument

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -917,7 +917,7 @@ Config.prototype._diffDeep = function(object1, object2, depth) {
   for (var parm in object2) {
     var value1 = object1[parm];
     var value2 = object2[parm];
-    if (value2 && typeof(value2) == 'object') {
+    if (value1 && value2 && typeof(value2) == 'object') {
       if (!(t._equalsDeep(value1, value2))) {
         diff[parm] = t._diffDeep(value1, value2, depth - 1);
       }


### PR DESCRIPTION
`Config.prototype._diffDeep` crashes if called with a value of `undefined` for the `object1` parameter, but the recursive calls of the method could make it happen.

Example code which would have caused a crash :
`var obj1 = {a: {}};
var obj2 = {a: {b: {c: 'd'}}};
t._diffDeep(obj1, obj2);`
