### PR TITLE
Json-schema Validation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,9 +16,11 @@ var DEFAULT_CLONE_DEPTH = 6,
     CONFIG_DIR = process.env['NODE_CONFIG_DIR'] || process.cwd() + '/config',
     runtimeJsonFilename = process.env['NODE_CONFIG_RUNTIME_JSON'] || CONFIG_DIR + '/runtime.json',
     appInstance = process.env['NODE_APP_INSTANCE'],
+    schemaValidatorFilename = process.env['NODE_CONFIG_SCHEMA_VALIDATOR'] || CONFIG_DIR + '/schema_validator.json',
     originalConfig = null,       // Not including the runtime.json values
     runtimeJson = {},            // Current runtimeJson extensions
     runtimeJsonWatcher = null,   // Filesystem watcher for runtime.json
+    schemaValidator = {},
     isQueuedForPersistence = false;
 
 /**
@@ -103,6 +105,7 @@ var Config = function() {
   var t = this;
   t._loadFileConfigs();
   t._persistConfigsOnChange();
+  t._schemaValidation();
 };
 
 /**
@@ -1172,6 +1175,51 @@ Config.prototype.resetRuntime = function(callback) {
         }
     });
 }
+
+/**
+ * <p>Support Json Schema validation for config</p>
+ *
+ * <p>
+ * This method allows you validate config thru json schema in a file.
+ * </p>
+ *
+ * @protected
+ * @method _schemaValidation
+ */
+Config.prototype._schemaValidation = function() {
+    var t = this;
+    var jaySchema = require('jayschema');
+    var jsonSchemaValidator = new jaySchema();
+    if(FileSystem.existsSync(schemaValidatorFilename)) {
+        try {
+            schemaValidator = FileSystem.readFileSync(schemaValidatorFilename, 'UTF-8');
+        }
+        catch (e) {
+            throw new Error('Schema Validator file ' + schemaValidatorFilename + ' cannot be read');
+        }
+        if(schemaValidator) {
+            jsonSchemaValidator.validate(t , JSON.parse(schemaValidator), function(errs) {
+                if (errs) { console.error('validation errors:\n', errs); }
+                else { console.log('no validation errors!'); }
+            });
+        }
+    }
+}
+
+/**
+ * <p>Exposing json schema</p>
+ *
+ * <p>
+ * This method allows get the validation json schema
+ * </p>
+ *
+ * @method getSchemaValidator
+ * @return {object} The validation json schema is returned
+ */
+Config.prototype.getSchemaValidator = function() {
+    return JSON.parse(schemaValidator);
+}
+
 
 // Assure the configuration object is a singleton.
 global.NODE_CONFIG = global.NODE_CONFIG ? global.NODE_CONFIG : new Config();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "directories": {"lib": "./lib", "config": "./config", "test": "./test"},
   "licenses": ["MIT"],
   "dependencies": {
+    "jayschema" : "0.1.5"
   },
   "devDependencies": {
     "js-yaml" : "0.3.x",


### PR DESCRIPTION
In [Caspa](https://github.com/inaes-tic/mbc-caspa) we need [Json-schema](http://json-schema.org/) for validate config file and to have info about config fields.

I have added jayschema module to validate.

If you want to merge it, please tell me so I can add documentation and tests.
