### PR TITLE
Fix array handling so new array values replace old ones wholesale

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -193,7 +193,7 @@ Config.prototype.watch = function(object, property, handler, depth) {
 
           // Return early if no change
           var origValue = o[prop];
-          if (origValue === newValue)
+          if (t._equalsDeep(origValue, newValue))
             return;
 
           // Remember the new value, and return if we're in another setter
@@ -999,9 +999,14 @@ Config.prototype._diffDeep = function(object1, object2, depth) {
   for (var parm in object2) {
     var value1 = object1[parm];
     var value2 = object2[parm];
-    if (value1 && value2 && typeof(value2) == 'object') {
+    if (value1 && value2 && t._isObject(value2)) {
       if (!(t._equalsDeep(value1, value2))) {
         diff[parm] = t._diffDeep(value1, value2, depth - 1);
+      }
+    }
+    else if (Array.isArray(value1) && Array.isArray(value2)) {
+      if(!t._equalsDeep(value1, value2)) {
+        diff[parm] = value2;
       }
     }
     else if (value1 !== value2){

--- a/test/1-protected-test.js
+++ b/test/1-protected-test.js
@@ -210,8 +210,8 @@ exports.PrivateTest = vows.describe('Protected (hackable) utilities test').addBa
       assert.isTrue(Object.keys(CONFIG._diffDeep(a, b)).length == 0);
     },
     'Returns an empty object if no differences (deep)': function() {
-      var a = {value_3: 14, hello:'world', value_1: 29, deepObj:{a:22,b:{c:45,a:44}}};
-      var b = {value_1: 29, hello:'world', value_3: 14, deepObj:{a:22,b:{a:44,c:45}}};
+      var a = {value_3: 14, hello:'world', value_1: 29, value_4:[1,'hello',2], deepObj:{a:22,b:{c:45,a:44}}};
+      var b = {value_1: 29, hello:'world', value_3: 14, value_4:[1,'hello',2], deepObj:{a:22,b:{a:44,c:45}}};
       assert.equal(typeof(CONFIG._diffDeep(a,b)), 'object');
       assert.isTrue(Object.keys(CONFIG._diffDeep(a, b)).length == 0);
     },
@@ -223,14 +223,15 @@ exports.PrivateTest = vows.describe('Protected (hackable) utilities test').addBa
       assert.equal(diff.hello, 'world');
     },
     'Returns just the diff values (deep)': function() {
-      var a = {value_3: 14, hello:'wurld', value_1: 29, deepObj:{a:22,b:{c:45,a:44}}};
-      var b = {value_1: 29, hello:'wurld', value_3: 14, deepObj:{a:22,b:{a:45,c:44}}};
+      var a = {value_3: 14, hello:'wurld', value_1: 29, value_4:[1,'hello',2], deepObj:{a:22,b:{c:45,a:44}}};
+      var b = {value_1: 29, hello:'wurld', value_3: 14, value_4:[1,'goodbye',2], deepObj:{a:22,b:{a:45,c:44}}};
       var diff = CONFIG._diffDeep(a,b);
-      assert.equal(Object.keys(diff).length, 1);
+      assert.equal(Object.keys(diff).length, 2);
       assert.equal(Object.keys(diff.deepObj).length, 1);
       assert.equal(Object.keys(diff.deepObj.b).length, 2);
       assert.equal(diff.deepObj.b.a, 45);
       assert.equal(diff.deepObj.b.c, 44);
+      assert.deepEqual(diff.value_4, [1, 'goodbye', 2]);
     }
   },
 

--- a/test/config/default.json
+++ b/test/config/default.json
@@ -2,9 +2,11 @@
   "Customers": {
     "dbName":"from_default_json",
     "dbPassword":"password will be overwritten.",
-    "dbPassword2":"password will be overwritten."
+    "dbPassword2":"password will be overwritten.",
+    "lang":["en","es"]
   },
   "AnotherModule": {
     "parm1":"value1"
-  }
+  },
+  "staticArray": [2,1,3]
 }

--- a/test/config/local-test.json
+++ b/test/config/local-test.json
@@ -1,5 +1,6 @@
 {
   "Customers": {
-    "dbPassword2":"another password"
+    "dbPassword2":"another password",
+    "lang":["en","de","es"]
   }
 }

--- a/test/config/runtime.json
+++ b/test/config/runtime.json
@@ -9,5 +9,9 @@
     "parm_number_1": "overridden from test",
     "parm2": 13
   },
-  "watchThisValue": 87261
+  "watchThisValue": 85935,
+  "dynamicArray": [
+    59524,
+    33370
+  ]
 }


### PR DESCRIPTION
Previously, if you made runtime configuration changes to array values, the value would change into an object with numbered keys (instead of staying as an array).

This has been brought up a couple other times (#28, #73). I agree that how to merge arrays is a little more ambiguous, but I find the current behavior particularly confusing. If you were using arrays only in static config files, then arrays were actually already working in a wholesale replacement fashion (an array value in `hostname.json` would completely replace that same config value defined in `default.json`). It was only when you introduced runtime configuration changes into the mix that the configuration value you were interacting with suddenly changed from an array into a generic object (with numbered keys). This was due to how the configuration diff got generated for keeping track of runtime changes.

Since host specific or deployment specific config overrides were already behaving in this wholesale replacement fashion, I fixed things so live configuration changes also got treated in a similar fashion.

More generally, I'd also vote that wholesale replacement is the most intuitive approach for dealing with arrays (rather than trying to deal with additive, merge-by-value, or merge-by-index approaches). This admittedly might just be my use-cases, but a few reasons:
- The other approaches seem more complex and also introduce other issues (eg, how to reset or remove array values if additive were the default)
- If you really wanted another merging strategy, you could at least now code that yourself while making runtime changes (eg, you could manually append values to an existing array and then make a wholesale replacement with the new array).
- (For what it's worth, wholesale replacement of array values is also the strategy the popular [nconf](https://github.com/flatiron/nconf/blob/62589145f33c8abe63f0d86e0bc8f3756223fc7b/lib/nconf/stores/memory.js#L156-L162) uses and I haven't seen any complaints there about that approach)
