### PR TITLE
The 'js-yaml' module is now preferred to 'yaml'.

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -87,7 +87,7 @@
   </pre>
   <p>
     Where EXT can be .yml, .yaml, .coffee, .json, or .js depending on the format you prefer.
-    NOTE: If you use .yml, .yaml, or .coffee file extensions, the 'yaml' or 'coffee-script'
+    NOTE: If you use .yml, .yaml, or .coffee file extensions, the 'js-yaml' or 'coffee-script'
     modules must be available.  These external dependencies are not included from
     this package.
   </p>


### PR DESCRIPTION
Greetings from a former Python/Zope/Plone aficionado in Berlin,  who started to use Node.js a week ago.

Your configuration system seems to be outstanding!
