### PR TITLE
Ensure writes to runtime.json are atomic

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -532,6 +532,35 @@ Config.prototype.watchForConfigFileChanges = function(interval) {
 };
 
 /**
+ * <p>Safely write a file</p>
+ *
+ * <p>
+ * This method safely overwrites a file by first writing to a temporary file
+ * and then renaming it. This to ensure no other process reads to file in a
+ * truncated state.
+ * </p>
+ *
+ * @method safeWriteFile
+ * @param filename {String} Filename to write to.
+ * @param content  {String} Data to write.
+ * @param callback {Function} Callback function.
+ */
+Config.prototype.safeWriteFile = function(filename, data, callback) {
+    var rand = Math.floor(Math.random() * (1 << 30)),
+        tmpFilename = filename + '.tmp-' + rand;
+
+    FileSystem.writeFile(tmpFilename, data, 'utf-8', function (err) {
+        if (err) {
+            return callback(err);
+        }
+
+        FileSystem.rename(tmpFilename, filename, function (err) {
+            callback(err);
+        });
+    });
+}
+
+/**
  * Return the sources for the configurations
  *
  * <p>
@@ -581,7 +610,7 @@ Config.prototype._persistConfigsOnChange = function(objectToWatch) {
       // Persist if necessary
       var newDiffs = t._diffDeep(originalConfig, t);
       if (!t._equalsDeep(newDiffs, runtimeJson)) {
-        FileSystem.writeFile(RUNTIME_JSON_FILENAME, JSON.stringify(newDiffs, null, 2), 'utf-8', function(error){
+        t.safeWriteFile(RUNTIME_JSON_FILENAME, JSON.stringify(newDiffs, null, 2), function(error){
           if (error)
             console.error("Error writing " + RUNTIME_JSON_FILENAME, error);
         });
@@ -1303,12 +1332,13 @@ Config.prototype.getOriginalConfig = function() {
  * @param callback {function} An optional callback function
  */
 Config.prototype.resetRuntime = function(callback) {
-    FileSystem.writeFile(RUNTIME_JSON_FILENAME, '{}', function(err, written, buffer) {
+    this.safeWriteFile(RUNTIME_JSON_FILENAME, '{}', function(err, written, buffer) {
         if(err) {
             console.log("Cannot write runtime.json file " + err);
             if (callback && typeof(callback) === 'function') {
                 callback(err);
             }
+            return;
         }
         console.log("Write to runtime.json completed");
         if (callback && typeof(callback) === 'function') {


### PR DESCRIPTION
By writing to a temporary file `runtime.json.tmp` and the renaming it
the risk of other processes reading a truncated file is eliminated.
