### PR TITLE
use path.join to build default CONFIG_DIR value

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,8 @@
 var Yaml = null,    // External libraries are lazy-loaded
     VisionmediaYaml = null,  // only if these file types exist.
     Coffee = null,
-    FileSystem = require('fs');
+    FileSystem = require('fs'),
+    Path = require('path');
 
 // Static members
 var DEFAULT_CLONE_DEPTH = 20,
@@ -104,7 +105,7 @@ var Config = function() {
 
   // Initialize parameters from command line, environment, or default
   NODE_ENV = t._initParam('NODE_ENV', 'development');
-  CONFIG_DIR = t._initParam('NODE_CONFIG_DIR', process.cwd() + '/config');
+  CONFIG_DIR = t._initParam('NODE_CONFIG_DIR', Path.join(__dirname, 'config'));
   RUNTIME_JSON_FILENAME = t._initParam('NODE_CONFIG_RUNTIME_JSON', CONFIG_DIR + '/runtime.json');
   DISABLE_FILE_WATCH = t._initParam('NODE_CONFIG_DISABLE_FILE_WATCH');
   PERSIST_ON_CHANGE = t._initParam('NODE_CONFIG_PERSIST_ON_CHANGE');


### PR DESCRIPTION
Currently the default CONFIG_DIR variable is built using process.cwd(), however node may not always be running in the same directory as the application, which can lead to odd behaviour. Using path.join(__dirname, 'config') should make things a little more robust whilst retaining the original intention (I think!).
