### PR TITLE
Removing console.log from resetRuntime() function

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1343,7 +1343,6 @@ Config.prototype.resetRuntime = function(callback) {
             }
             return;
         }
-        console.log("Write to runtime.json completed");
         if (callback && typeof(callback) === 'function') {
             callback(null, written, buffer);
         }


### PR DESCRIPTION
As a consequence of: https://github.com/lorenwest/node-config/commit/7467d3935658bf29a5904cc8224f4ec2f631032f#commitcomment-5228985
