### PR TITLE
Change FileSystem.watch to FileSystem.watchFile

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -503,7 +503,7 @@ Config.prototype.watchForConfigFileChanges = function(interval) {
   try {
     if (FileSystem.watch) {
       // This is the latest
-      runtimeJsonWatcher = FileSystem.watch(RUNTIME_JSON_FILENAME, {persistent:false}, function(event, filename) {
+      runtimeJsonWatcher = FileSystem.watchFile(RUNTIME_JSON_FILENAME, {persistent:false}, function(event, filename) {
 
         // Re-attach watcher on inode change (happens when some editors save a file)
         // Wait for the O/S rename to complete, then re-watch the file


### PR DESCRIPTION
 This fixes https://github.com/lorenwest/node-config/issues/110.   watchFile will cause the runtime.json to be checked for changes more than once on osx.
