### PR TITLE
Use svg for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-config
 ===========
 
-[![Build Status](https://secure.travis-ci.org/lorenwest/node-config.png?branch=master)](https://travis-ci.org/lorenwest/node-config)<br>
+[![Build Status](https://secure.travis-ci.org/lorenwest/node-config.svg?branch=master)](https://travis-ci.org/lorenwest/node-config)<br>
 [![NPM](https://nodei.co/npm/config.png?downloads=true&stars=true)](https://nodei.co/npm/config/)<br>
 [![NPM](https://nodei.co/npm-dl/config.png?months=9)](https://nodei.co/npm/config/)
 


### PR DESCRIPTION
Hello!

Just an extremely minor patch here. You see, on my phone these png build icons looks a bit... not so crisp. And seeing as travis now offers svg icons, that would look even better. So if you want, this fixes that.

Other than that, great stuff, thanks. And have a great day!
