### PR TITLE
catch error when requiring visionmedia yaml module

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -746,8 +746,11 @@ util.parseFile = function(fullFilename) {
           Yaml = require('js-yaml');
         }
         catch (e) {
-          // If it doesn't exist, load the fallback visionmedia yaml module.
-          VisionmediaYaml = require('yaml');
+          try {
+            // If it doesn't exist, load the fallback visionmedia yaml module.
+            VisionmediaYaml = require('yaml');
+          }
+          catch (e) { }
         }
       }
 


### PR DESCRIPTION
Catches requiring error, so that the "No YAML parser loaded..." message get chance to be shown
