### PR TITLE
Issue #148: Adding support for .properties files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -8,6 +8,7 @@ var Yaml = null,    // External libraries are lazy-loaded
     VisionmediaYaml = null,  // only if these file types exist.
     Coffee = null,
     CSON = null,
+    PPARSER = null,
     Utils = require('util'),
     FileSystem = require('fs');
 
@@ -555,7 +556,8 @@ util.getConfigSources = function() {
  * <p>
  * EXT can be yml, yaml, coffee, json, cson or js signifying the file type.
  * yaml (and yml) is in YAML format, coffee is a coffee-script,
- * json is in JSON format, cson is in CSON format, and js is a javascript executable file that is
+ * json is in JSON format, cson is in CSON format, properties is in .properties format
+ * (http://en.wikipedia.org/wiki/.properties), and js is a javascript executable file that is
  * require()'d with module.exports being the config object.
  * </p>
  *
@@ -630,7 +632,7 @@ util.loadFileConfigs = function() {
 
   // Read each file in turn
   var baseNames = ['default', NODE_ENV, hostName, hostName + '-' + NODE_ENV, 'local', 'local-' + NODE_ENV];
-  var extNames = ['js', 'json', 'coffee', 'yaml', 'yml', 'cson'];
+  var extNames = ['js', 'json', 'coffee', 'yaml', 'yml', 'cson', 'properties'];
   baseNames.forEach(function(baseName) {
     extNames.forEach(function(extName) {
 
@@ -709,7 +711,8 @@ util.loadFileConfigs = function() {
  * .json = File is parsed using JSON.parse()
  * .coffee = File to run that has a module.exports with coffee-script containing the config object
  * .yaml (or .yml) = Parsed with a YAML parser
- * .cson (or .cson) = Parsed with a CSON parser
+ * .cson = Parsed with a CSON parser
+ * .properties = Parsed with the 'properties' node package
  *
  * If the file doesn't exist, a null will be returned.  If the file can't be
  * parsed, an exception will be thrown.
@@ -791,6 +794,12 @@ util.parseFile = function(fullFilename) {
       }
       // Allow comments in CSON files
       configObject = CSON.parseSync(util.stripComments(fileContent));
+    }
+    else if (extension == 'properties') {
+      if (!PPARSER) {
+        PPARSER = require('properties');
+      }
+      configObject = PPARSER.parse(fileContent, { namespaces: true });
     }
     else if (extension == 'js') {
       // Use the built-in parser for .js files

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "js-yaml" : "2.1.x",
     "coffee-script" : ">=1.7.0",
     "vows" : ">=0.5.13",
-    "cson" : "1.4.0"
+    "cson" : "~1.4.0",
+    "properties" : "~1.2.1"
   },
   "repository": {
     "type" : "git",

--- a/test/1-protected-test.js
+++ b/test/1-protected-test.js
@@ -464,6 +464,26 @@ exports.PrivateTest = vows.describe('Protected (hackable) utilities test').addBa
     }
   },
 
+  '.properties parse tests': {
+    topic: function() {
+      return CONFIG.util.parseFile(__dirname + '/config/default.properties');
+    },
+    'The function exists': function() {
+      assert.isFunction(CONFIG.util.parseFile);
+    },
+    'An object is returned': function(config) {
+      assert.isObject(config);
+    },
+    'The correct object is returned': function(config) {
+      assert.isObject(config.AnotherModule);
+      assert.isTrue(config.AnotherModule.parm5 == "value5");
+      assert.isObject(config['key with spaces']);
+      assert.isTrue(config['key with spaces'].another_key == 'hello');
+      assert.isUndefined(config.ignore_this_please);
+      assert.isUndefined(config.i_am_a_comment);
+    }
+  },
+
   'loadFileConfigs() tests': {
     topic: function() {
       return CONFIG.util.loadFileConfigs();

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -73,6 +73,10 @@ exports.ConfigTest = vows.describe('Test suite for node-config').addBatch({
       assert.equal(CONFIG.AnotherModule.parm4, 'value4');
     },
 
+    'Loading configurations from a .properties file is correct': function() {
+      assert.equal(CONFIG.AnotherModule.parm5, 'value5');
+    },
+
     'Loading configurations from an environment file is correct': function() {
       assert.equal(CONFIG.Customers.dbPort, '5999');
     },

--- a/test/config/default.properties
+++ b/test/config/default.properties
@@ -1,0 +1,4 @@
+AnotherModule.parm5 = value5
+key\ with\ spaces.another_key = hello
+!ignore_this_please = something
+#i_am_a_comment = something


### PR DESCRIPTION
[properties-parser](https://github.com/xavi-/node-properties-parser) doesn't seem to provide a very full featured API nor much documentation at all, it also does not support the kind of deep object creation specified.

For example:

``` properties
thing1.thing2 = something
```

Becomes:

``` json
{
  "thing1.thing2": "something"
}
```

Whereas [properties](https://github.com/gagle/node-properties) does make a nested object if you specify that you want it to use namespaces. And properly renders:

``` json
{
  "thing1": {
    "thing2": "something"
  }
}
```

As a result, I opted to use [properties](https://github.com/gagle/node-properties) even though its a bit older.
