### PR TITLE
Add test coverage to show that when a getter references an overriden value.  Resolves #157.

### DIFF
--- a/test/1-protected-test.js
+++ b/test/1-protected-test.js
@@ -503,7 +503,7 @@ exports.PrivateTest = vows.describe('Protected (hackable) utilities test').addBa
     },
     'The correct object is returned': function(config) {
       assert.isObject(config.Customers);
-      assert.isTrue(config.Customers.dbHost == 'base');
+      assert.isTrue(config.Customers.dbHost == 'YamlHost');
       assert.isTrue(config.Customers.dbName == 'override_from_runtime_json');
     }
   },

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -49,7 +49,7 @@ exports.ConfigTest = vows.describe('Test suite for node-config').addBatch({
     },
 
     'Loading configurations from a JS module is correct': function() {
-      assert.equal(CONFIG.Customers.dbHost, 'base');
+      assert.equal(CONFIG.Customers.dbPort, 3);
       assert.equal(CONFIG.TestModule.parm1, 'value1');
     },
 
@@ -82,7 +82,7 @@ exports.ConfigTest = vows.describe('Test suite for node-config').addBatch({
     },
 
     'Loading configurations from an environment file is correct': function() {
-      assert.equal(CONFIG.Customers.dbPort, '5999');
+      assert.equal(CONFIG.Customers.dbHost, 'YamlHost');
     },
 
     'Loading configurations from the local file is correct': function() {
@@ -219,16 +219,20 @@ exports.ConfigTest = vows.describe('Test suite for node-config').addBatch({
       assert.isTrue(typeof config.get('TestModule') === 'object');
     },
     'A sub level item is returned': function(config) {
-      assert.equal(config.get('Customers.dbHost'), 'base');
+      assert.equal(config.get('Customers.dbHost'), 'YamlHost');
     },
     'get is attached deeply': function(config) {
-      assert.equal(config.Customers.get('dbHost'), 'base');
+      assert.equal(config.Customers.get('dbHost'), 'YamlHost');
     },
     'An extended property accessor remains a getter': function(config) {
-      assert.equal(config.get('customerDbPort'), '5999');
+      assert.equal(config.get('customerDbPort'), '3');
     },
     'A cloned property accessor remains a getter': function(config) {
-      assert.equal(config.Customers.get('dbString'), 'override_from_runtime_json:5999');
+      assert.equal(config.Customers.get('dbString'), 'override_from_runtime_json:3');
+    },
+    // Same test as above, but with a second label because it tests two things
+    'A getter references the overridden value, not the original value': function(config) {
+      assert.equal(config.Customers.get('dbString'), 'override_from_runtime_json:3');
     },
     'A cloned property accessor is made immutable': function(config) {
       var random1 = config.Customers.get('random'),

--- a/test/config/local-3.js
+++ b/test/config/local-3.js
@@ -1,0 +1,8 @@
+
+var config = {
+  Customers : {
+    dbPort : 3,
+  },
+};
+
+module.exports = config;

--- a/test/config/test.yaml
+++ b/test/config/test.yaml
@@ -1,4 +1,5 @@
 # This is loaded if $NODE_ENV=test
 
 Customers:
+  dbHost: 'YamlHost'
   dbPort: 5999


### PR DESCRIPTION
The overridden value is returned.

```
    That is, confirming that the value returned by the getter is
   resolved at call-time, not declaration-time.

    The test I really care about here is how dbString gets resolved.

    The other tests are updated because of the interdependent and
   cascading relationship between the configuration values.

    Note that while these tests pass, when the tests are made to
   /fail/ for me, node crashes instead instead of the test
   returning false, the error is:

    "RangeError: Maximum call stack size exceeded".
```
