### PR TITLE
Add support for defered configuration values.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,8 @@ var Yaml = null,    // External libraries are lazy-loaded
     CSON = null,
     PPARSER = null,
     JSON5 = null,
+    deferConfig = require('./config/defer').deferConfig,
+    DeferredConfig = require('./config/defer').DeferredConfig,
     Utils = require('util'),
     FileSystem = require('fs');
 
@@ -701,9 +703,39 @@ util.loadFileConfigs = function() {
   var runtimeJson = util.parseFile(RUNTIME_JSON_FILENAME) || {};
   util.extendDeep(config, runtimeJson);
 
+  util.resolveDeferredConfigs(config);
+
   // Return the configuration object
   return config;
 };
+
+// Using basic recursion pattern, find all the deferred values and resolve them.
+util.resolveDeferredConfigs = function (config) {
+    var completeConfig = config;
+
+    function _iterate (prop) {
+      for (var property in prop) {
+          if (prop.hasOwnProperty(property) && prop[property] != null) {
+              if (prop[property].constructor == Object) {
+                  _iterate(prop[property]);
+              } else if (prop[property].constructor == Array) {
+                  for (var i = 0; i < prop[property].length; i++) {
+                      _iterate(prop[property][i]);
+                  }
+              } else {
+                  if (prop[property] instanceof DeferredConfig ) {
+                    prop[property]= prop[property].resolve(completeConfig)
+                  }
+                  else {
+                    // Nothing to do. Keep the property how it is.
+                  }
+              }
+          }
+      }
+    }
+
+    _iterate(config);
+}
 
 /**
  * Parse and return the specified configuration file.
@@ -1463,6 +1495,8 @@ var utilWarnings = {};
     return util[newName].apply(this, arguments);
   }
 });
+
+
 
 // Instantiate and export the configuration
 var config = module.exports = new Config();

--- a/lib/config/defer.js
+++ b/lib/config/defer.js
@@ -1,0 +1,14 @@
+// Create a deferredConfig prototype so that we can check for it when reviewing the configs later.
+function DeferredConfig () {
+}
+DeferredConfig.prototype.resolve = function (config) {};
+
+// Accept a function that we'll use to resolve this value later and return a 'deferred' configuration value to resolve it later.
+function deferConfig (func) {
+  var obj = Object.create(DeferredConfig.prototype);
+  obj.resolve = func;
+  return obj;
+}
+
+module.exports.deferConfig = deferConfig;
+module.exports.DeferredConfig = DeferredConfig;

--- a/test/3-deferred-configs.js
+++ b/test/3-deferred-configs.js
@@ -1,0 +1,49 @@
+
+// Test declaring deferred values.
+// The key config files involved here are:
+//      test/config/default-defer.js
+//      test/config/local-defer.js
+
+
+// Change the configuration directory for testing
+process.env.NODE_CONFIG_DIR = __dirname + '/config';
+
+// Hardcode $NODE_ENV=test for testing
+process.env.NODE_ENV='test';
+
+// Test for multi-instance applications
+process.env.NODE_APP_INSTANCE='defer';
+
+// Because require'ing config creates and caches a global singleton,
+// We have to invalidate the cache to build new object based on the environment variables above
+var CONFIG = requireUncached('../lib/config');
+
+// Dependencies
+var vows = require('vows'),
+    assert = require('assert');
+
+exports.DeferredTest = vows.describe('Tests for deferred values').addBatch({
+  'Configuration file Tests': {
+    topic: function() {
+      return CONFIG;
+    },
+
+    'Using deferConfig() in a config file causes value to be evaluated at the end': function() {
+        // The deferred function was declared in default-defer.js
+        // Then local-defer.js is located which overloads the siteTitle mentioned in the function
+        // Finally the deferred configurations, now referencing the 'local' siteTitle
+        assert.equal(CONFIG.welcomeEmail.subject, 'Welcome to New Instance!');
+    },
+
+    'values which are functions remain untouched unless they are instance of DeferredConfig': function() {
+        // If this had been treated as a deferred config value it would blow-up.
+        assert.equal(CONFIG.welcomeEmail.aFunc(), 'Still just a function.');
+    },
+  }
+});
+
+
+function requireUncached(module){
+   delete require.cache[require.resolve(module)];
+   return require(module);
+}

--- a/test/config/default-defer.js
+++ b/test/config/default-defer.js
@@ -1,0 +1,21 @@
+
+var defer = require('../../lib/config/defer').deferConfig;
+
+var config = {
+  siteTitle : 'Site title',
+};
+
+// Set up a default value which refers to another value.
+// The resolution of the value is deferred until all the config files have been loaded
+// So that if 'config.siteTitle' is overridden, this will point to the correct value.
+config.welcomeEmail = {
+  subject :  defer(function (cfg) {
+    return "Welcome to "+cfg.siteTitle;
+  }),
+  // A plain function should be not disturbed.
+  aFunc  : function () {
+    return "Still just a function.";
+  }
+};
+
+module.exports = config;

--- a/test/config/local-defer.js
+++ b/test/config/local-defer.js
@@ -1,0 +1,6 @@
+
+var config = {
+ siteTitle : 'New Instance!',
+};
+
+module.exports = config;


### PR DESCRIPTION
As seen in the included tests, a new feature is added to allow you declare a
configuration value as a special kind of function in .js files.

This is useful to create default configuration values based on other 
configuration values when other further configuration files may override the
values being referenced.

You can think of this as allowing you declare "templates" which contain 
variables referencing other config values in the configuration file, which are
then "rendered" with the correct values once all the config files have been
loaded in merged.

One test shows that the addition is backwards compatible with config files
that have been using functions as values. Only functions which are instance of
the newly provided DeferredConfig class are handled specially.

For example use see:

```
    test/3-deferred-configs.js
   test/config/default-defer.js
   test/config/local-defer.js
```

---

I looked for other names to avoid the name 'defer' and 'deferred', since 'deferred' is used
by some promise library. Finding nothing that better conveyed what this feature does, I settled
on the name 'deferConfig', which will not conflict with promise libraries name of 'defer' or 'deferred'.
However, people can alias the name to simply 'defer()' in their config files upon import if they
prefer the shorter name.

---

Note also the use of module un-loading / reloading in the new test file.

I found adding tests to the "2" test file to be challenging because it references
so many configuration files and values with a complex cascading relationship.

By using the unload/reload pattern, I was able to a small isolated test that is
easy to review and maintain without intefering with the existing battery of
tests.
