### PR TITLE
Simplify the definition of defer() functions.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,15 @@
+
+1.8.1 / 2014-11-14
+==================
+
+  * Simplify syntax for defer() functions. The 'this' value in the functions is now bound
+    to the main configuration object, so it doesn't have to be passed into the function.
+
 1.8.0 / 2014-11-13
 ==================
 
-  * Added deferred function for evaluating configs after load
+  * Added deferred function for evaluating configs after load (@markstos)
+    For details, see: https://github.com/lorenwest/node-config/wiki/Configuration-Files#javascript-module---js
   * Bumped js-yaml dependency (@markstos)
 
 1.7.0 / 2014-10-30

--- a/lib/config.js
+++ b/lib/config.js
@@ -724,7 +724,7 @@ util.resolveDeferredConfigs = function (config) {
                   }
               } else {
                   if (prop[property] instanceof DeferredConfig ) {
-                    prop[property]= prop[property].resolve(completeConfig)
+                    prop[property]= prop[property].resolve.call(completeConfig,completeConfig)
                   }
                   else {
                     // Nothing to do. Keep the property how it is.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "./lib/config.js",
   "description": "Configuration control for production node deployments",
   "author": "Loren West <open_source@lorenwest.com>",

--- a/test/3-deferred-configs.js
+++ b/test/3-deferred-configs.js
@@ -39,6 +39,12 @@ exports.DeferredTest = vows.describe('Tests for deferred values').addBatch({
         // If this had been treated as a deferred config value it would blow-up.
         assert.equal(CONFIG.welcomeEmail.aFunc(), 'Still just a function.');
     },
+
+    // This defer function didn't use args, but relied 'this' being bound to the main config object
+    "defer functions can simply refer to 'this'" : function () {
+        assert.equal(CONFIG.welcomeEmail.justThis, 'Welcome to this New Instance!');
+    }
+
   }
 });
 

--- a/test/config/default-defer.js
+++ b/test/config/default-defer.js
@@ -15,7 +15,13 @@ config.welcomeEmail = {
   // A plain function should be not disturbed.
   aFunc  : function () {
     return "Still just a function.";
-  }
+  },
+
+  // Look ma, no arg passing. The main config object is bound to 'this'
+  justThis: defer(function () {
+    return "Welcome to this "+this.siteTitle;
+  }),
+
 };
 
 module.exports = config;


### PR DESCRIPTION
Before: you had to pass in the config object:

```
before: defer(function (cfg) {
 return "Welcome to  "+cfg.siteTitle;
```

   }),

After: 'this' is now bound to the main config object, so it doesn't have to be
passed in:

```
after: defer(function () {
 return "Welcome to  "+this.siteTitle;
```

   }),

For backwards-compatibility, the config object is also still passed in as an
argument.
(Although it's unlikely that anyone started using this feature, since it has
only been for a few hours, and not well-documented for most of that time).

Automated tests are included to check this works.
