### PR TITLE
Update README to mention that get() throws excewptions, and also `config.has()`. Addresses #173.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,8 @@
 
+
+  * Highlight `config.has()` in the README. Use it to check to if a value exists, since `config.get()`
+    throws exceptions on undefined values. (@markstos)
+
 1.8.1 / 2014-11-14
 ==================
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ The following examples are in JSON format, but configurations can be in other [f
     var dbConfig = config.get('Customer.dbConfig');
     db.connect(dbConfig, ...);
 
+    if (config.has('optionalFeature.detail')) {
+      var detail = config.get('optionalFeature.detail');
+      ...
+    }
+
+`config.get()` will throw an exception for undefined keys to help catch typos and missing values.
+Use `config.has()` to test if a configuration value is defined.
+
 **Start your app server:**
 
     $ export NODE_ENV=production


### PR DESCRIPTION
These are important and common details to encounter, and worth mentioning up
front.
