### PR TITLE
BugFix: deferred values should be treated like atomic values, not objects.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1266,8 +1266,9 @@ util.extendDeep = function(mergeInto) {
     // Cycle through each element of the object to merge from
     for (var prop in mergeFrom) {
 
-      // Extend recursively if both elements are objects
-      if (util.isObject(mergeInto[prop]) && util.isObject(mergeFrom[prop])) {
+      // Extend recursively if both elements are objects and target is not really a deferred function
+      var isDeferredFunc = mergeInto[prop] instanceof DeferredConfig;
+      if (util.isObject(mergeInto[prop]) && util.isObject(mergeFrom[prop]) && !isDeferredFunc) {
         util.extendDeep(mergeInto[prop], mergeFrom[prop], depth - 1);
       }
 

--- a/test/3-config/default.js
+++ b/test/3-config/default.js
@@ -3,6 +3,9 @@ var defer = require('../../defer').deferConfig;
 
 var config = {
   siteTitle : 'Site title',
+  latitude  : 1,
+  longitude : 2,
+
 };
 
 // Set up a default value which refers to another value.
@@ -21,7 +24,12 @@ config.welcomeEmail = {
   justThis: defer(function () {
     return "Welcome to this "+this.siteTitle;
   }),
+};
 
+config.map = {
+  centerPoint : defer(function () {
+    return { lat: this.latitude, lon: this.longitude };
+  }),
 };
 
 module.exports = config;

--- a/test/3-config/local.js
+++ b/test/3-config/local.js
@@ -3,4 +3,8 @@ var config = {
  siteTitle : 'New Instance!',
 };
 
+config.map = {
+  centerPoint :  { lat: 3, lon: 4 },
+};
+
 module.exports = config;

--- a/test/3-deferred-configs.js
+++ b/test/3-deferred-configs.js
@@ -35,7 +35,11 @@ exports.DeferredTest = vows.describe('Tests for deferred values').addBatch({
     // This defer function didn't use args, but relied 'this' being bound to the main config object
     "defer functions can simply refer to 'this'" : function () {
         assert.equal(CONFIG.welcomeEmail.justThis, 'Welcome to this New Instance!');
-    }
+    },
+
+    "defer functions which return objects should still be treated as a single value." : function () {
+      assert.deepEqual(CONFIG.get('map.centerPoint'), { lat: 3, lon: 4 });
+    },
 
   }
 });


### PR DESCRIPTION
There was an edge case when a deferred function returned an object.

  When extendDeep does its recursion and ran into a deferred value, it would
  continue to recurse into it, potentially doing a deep merge with a child
  config file.

  Because the deferred value did not get /replaced/ by the child object as
  intended, it continued to be an 'instanceof' the DeferredConfig prototype.

  So as a final step, the deferred function was executed to compute a final
  value when it should not have been.

  The result was this the child fails to properly override the deferred
  function with a static value, because deferred function was getting run
  anyway.

  The included test coverage illustrates such a case.

  This fix does not the affect the general utility of extendDeep, as only
  objects that are 'instanceof' the newly-introduced DeferredConfig object
  are effected.
