### PR TITLE
Added support for iced-coffee-script with .iced and .coffee extensions

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -870,7 +870,7 @@ util.parseFile = function(fullFilename) {
         //  Coffee = require("coffee-script");
         //}
         
-        Coffee = require("coffee-script")
+        Coffee = require("coffee-script");
 
         // coffee-script >= 1.7.0 requires explicit registration for require() to work
         if (Coffee.register) {


### PR DESCRIPTION
`iced-coffee-script` is an extension of coffee-script with some cool async features added. This PR fixes a few issues regarding `iced-coffee-script`:
- `node-config` does not parse files with the .iced extension. These are now parsed with iced-coffee-script.
- `node-config` breaks compilation for projects where `iced-coffee-script` is used with `.coffee` files. In this case, `node-config` parses a `.coffee` config file with `coffee-script` and registers it, so that all further `.coffee` files are compiled with `coffee-script` and not `iced-coffee-script`. `node-config` now parses `.coffee` files with `iced-coffee-scripts`, if it exists, and falls back to `coffee-script` if it doesn't.
