### PR TITLE
More helpful exception

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -164,6 +164,9 @@ var getImpl= function(object, property) {
  * @return value {mixed} - The property value
  */
 Config.prototype.get = function(property) {
+  if(property === null || property === undefined){
+    throw new Error("Calling config.get with null or undefined argument");
+  }
   var t = this,
       value = getImpl(t, property);
 


### PR DESCRIPTION
When calling config.get() with parameters that are null or undefined, you get an unhelpful exception thrown in Config.getImpl(): "TypeError: Cannot call method 'split' of undefined"

This PR fails earlier with a more helpful error message indicating the specific error the user made.
I could also resubmit with an explicit test for arrays and strings if preferred as those seem to be the only options getImpl can handle. I also did not update tests as there already is a test to ensure AN exception is thrown in the case of attempting to access an invalid property, however this PR updates that with a more helpful exception.
