### PR TITLE
Code and tests for get() and has() to explicitly handle missing input.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -202,6 +202,10 @@ Config.prototype.get = function(property) {
  * @return isPresent {boolean} - True if the property is defined, false if not defined.
  */
 Config.prototype.has = function(property) {
+  // While get() throws an exception for undefined input, has() is designed to test validity, so false is appropriate
+  if(property === null || property === undefined){
+    return false;
+  }
   var t = this;
   return (getImpl(t, property) !== undefined);
 };

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -238,13 +238,13 @@ exports.ConfigTest = vows.describe('Test suite for node-config')
     'get(undefined) throws an exception': function() {
       assert.throws(
           function () { CONFIG.get(undefined); },
-          /Configuration property "undefined" is not defined/
+          /Calling config.get with null or undefined argument/
       );
     },
     'get(null) throws an exception': function() {
       assert.throws(
           function () { CONFIG.get(null); },
-          /Configuration property "null" is not defined/
+          /Calling config.get with null or undefined argument/
       );
     },
     "get('') throws an exception": function() {


### PR DESCRIPTION
Usually get() and has() are called with explicit inputs, but they can also be
called with a variable name, and that variable can unexpectly undefined or null,
as @robludwig found and submitted a patch for.

This pull request builds on his work by adding test coverage and also covering has()
as well as get().

@lorenwest: Note that for has() I have the code return _false_ on missing input
instead of throwing an exception like get() does.

The value of `has()` is that it works differently that get() does, precisely so people
can avoid a try/catch block around get().

Since `has()` is largely for avoiding try/catch, it made sense to have it avoid
throwing exceptions.
