### PR TITLE
Hjson Support

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@ var Yaml = null,    // External libraries are lazy-loaded
     PPARSER = null,
     JSON5 = null,
     TOML = null,
+    HJSON = null,
     deferConfig = require('../defer').deferConfig,
     DeferredConfig = require('../defer').DeferredConfig,
     Utils = require('util'),
@@ -653,7 +654,7 @@ util.loadFileConfigs = function() {
 
   // Read each file in turn
   var baseNames = ['default', NODE_ENV, hostName, hostName + '-' + NODE_ENV, 'local', 'local-' + NODE_ENV];
-  var extNames = ['js', 'json', 'json5', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties'];
+  var extNames = ['js', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties'];
   baseNames.forEach(function(baseName) {
     extNames.forEach(function(extName) {
 
@@ -847,6 +848,14 @@ util.parseFile = function(fullFilename) {
       }
 
       configObject = JSON5.parse(fileContent);
+
+    } else if (extension == 'hjson') {
+
+      if (!HJSON) {
+        HJSON = require('hjson');
+      }
+
+      configObject = HJSON.parse(fileContent);
 
     } else if (extension == 'toml') {
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "coffee-script": ">=1.7.0",
     "cson": "^1.6.1",
+    "hjson": "^1.2.0",
     "js-yaml": "^3.2.2",
     "json5": "~0.2.0",
     "properties": "~1.2.1",

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -87,6 +87,10 @@ exports.ConfigTest = vows.describe('Test suite for node-config')
       assert.equal(CONFIG.AnotherModule.parm7, 'value7');
     },
 
+    'Loading configurations from a Hjson file is correct': function() {
+      assert.equal(CONFIG.AnotherModule.parm8, 'value8');
+    },
+
     'Loading configurations from an environment file is correct': function() {
       assert.equal(CONFIG.Customers.dbPort, '5999');
     },

--- a/test/config/default.hjson
+++ b/test/config/default.hjson
@@ -1,0 +1,14 @@
+{
+  # Comment to test comment ignoring
+  // Comment to test comment ignoring
+  /* Comment to test comment ignoring */
+
+  Customers:
+  {
+    dbName: from_default_hjson
+  }
+  AnotherModule:
+  {
+    parm8: value8
+  }
+}


### PR DESCRIPTION
I've added support for Hjson, a configuration file format that's similar to JSON but with a simplified syntax.

It supports #, // and /**/ style comments as well as avoiding trailing/missing comma and other mistakes. For details and syntax see http://laktak.github.io/hjson/