### PR TITLE
Fixes an error message that was missing a word

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1530,7 +1530,7 @@ util.runStrictnessChecks = function (config) {
   });
   // devleopment is special-cased because it's the default value
   if (NODE_ENV && (NODE_ENV !== 'development') && !anyFilesMatchEnv) {
-    _warnOrThrow("NODE_ENV value of '"+NODE_ENV+"' did match any deployment config file names.");
+    _warnOrThrow("NODE_ENV value of '"+NODE_ENV+"' did not match any deployment config file names.");
   }
 
   // Throw an exception if there's no explict config file for NODE_APP_INSTANCE
@@ -1538,7 +1538,7 @@ util.runStrictnessChecks = function (config) {
       return filename.match(APP_INSTANCE);
   });
   if (APP_INSTANCE && !anyFilesMatchInstance) {
-    _warnOrThrow("NODE_APP_INSTANCE value of '"+APP_INSTANCE+"' did match any instance config file names.");
+    _warnOrThrow("NODE_APP_INSTANCE value of '"+APP_INSTANCE+"' did not match any instance config file names.");
   }
 
   // Throw if NODE_ENV matches' default' or 'local'

--- a/test/6-strict-mode.js
+++ b/test/6-strict-mode.js
@@ -7,7 +7,7 @@ vows.describe('Tests for strict mode').addBatch({
   "Specifying an unused NODE_ENV value and valid NODE_APP_INSTANCE value throws an exception": _expectException({
     NODE_ENV         : 'BOOM',
     APP_INSTANCE     : 'valid-instance',
-    exceptionMessage : "FATAL: NODE_ENV value of 'BOOM' did match any deployment config file names. "
+    exceptionMessage : "FATAL: NODE_ENV value of 'BOOM' did not match any deployment config file names. "
                      + "See https://github.com/lorenwest/node-config/wiki/Strict-Mode",
   }),
 
@@ -22,7 +22,7 @@ vows.describe('Tests for strict mode').addBatch({
   "Specifying an unused NODE_APP_INSTANCE and valid NODE_ENV value throws an exception": _expectException({
     NODE_ENV         : 'valid-deployment',
     APP_INSTANCE     : 'BOOM',
-    exceptionMessage : "FATAL: NODE_APP_INSTANCE value of 'BOOM' did match any instance config file names. "
+    exceptionMessage : "FATAL: NODE_APP_INSTANCE value of 'BOOM' did not match any instance config file names. "
                      + "See https://github.com/lorenwest/node-config/wiki/Strict-Mode",
   }),
 


### PR DESCRIPTION
Note that the following wiki page will also need to be updated: https://github.com/lorenwest/node-config/wiki/Strict-Mode

Of course, since many people will still have the old version and will Google the text of the error message, you may want to include both versions of the text in that wiki so they continue to find the answer.