### PR TITLE
Refactor: split up parseFile into a second function parseString for string-only based formats

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -760,12 +760,10 @@ util.resolveDeferredConfigs = function (config) {
  * The file extension determines the parser to use.
  *
  * .js = File to run that has a module.exports containing the config object
- * .json = File is parsed using JSON.parse()
  * .coffee = File to run that has a module.exports with coffee-script containing the config object
  * .iced = File to run that has a module.exports with iced-coffee-script containing the config object
- * .yaml (or .yml) = Parsed with a YAML parser
- * .cson = Parsed with a CSON parser
- * .properties = Parsed with the 'properties' node package
+ * All other supported file types (yaml, toml, json, cson, hjson, json5, properties)
+ * are parsed with util.parseString.
  *
  * If the file doesn't exist, a null will be returned.  If the file can't be
  * parsed, an exception will be thrown.
@@ -809,81 +807,7 @@ util.parseFile = function(fullFilename) {
 
   // Parse the file based on extension
   try {
-    if (extension === 'yaml' || extension === 'yml') {
-      if (!Yaml && !VisionmediaYaml) {
-        // Lazy loading
-        try {
-          // Try to load the better js-yaml module
-          Yaml = require('js-yaml');
-        }
-        catch (e) {
-          try {
-            // If it doesn't exist, load the fallback visionmedia yaml module.
-            VisionmediaYaml = require('yaml');
-          }
-          catch (e) { }
-        }
-      }
-
-      if (Yaml) {
-        configObject = Yaml.load(fileContent);
-      }
-      else if (VisionmediaYaml) {
-        // The yaml library doesn't like strings that have newlines but don't
-        // end in a newline: https://github.com/visionmedia/js-yaml/issues/issue/13
-        fileContent += '\n';
-        configObject = VisionmediaYaml.eval(util.stripYamlComments(fileContent));
-      }
-      else {
-        console.error("No YAML parser loaded.  Suggest adding js-yaml dependency to your package.json file.")
-      }
-    }
-    else if (extension == 'json') {
-      // Allow comments in JSON files
-      configObject = JSON.parse(util.stripComments(fileContent));
-    }
-    else if (extension == 'json5') {
-
-      if (!JSON5) {
-        JSON5 = require('json5');
-      }
-
-      configObject = JSON5.parse(fileContent);
-
-    } else if (extension == 'hjson') {
-
-      if (!HJSON) {
-        HJSON = require('hjson');
-      }
-
-      configObject = HJSON.parse(fileContent);
-
-    } else if (extension == 'toml') {
-
-      if(!TOML) {
-        TOML = require('toml');
-      }
-
-      configObject = TOML.parse(fileContent);
-    }
-    else if (extension == 'cson') {
-      if (!CSON) {
-        CSON = require('cson');
-      }
-      // Allow comments in CSON files
-      if (typeof CSON.parseSync === 'function') {
-        configObject = CSON.parseSync(util.stripComments(fileContent));
-      } else {
-        configObject = CSON.parse(util.stripComments(fileContent));
-      }
-    }
-    else if (extension == 'properties') {
-      if (!PPARSER) {
-        PPARSER = require('properties');
-      }
-      configObject = PPARSER.parse(fileContent, { namespaces: true, variables: true, sections: true });
-    }
-    else if (extension == 'js') {
+    if (extension == 'js') {
       // Use the built-in parser for .js files
       configObject = require(fullFilename);
     }
@@ -921,6 +845,9 @@ util.parseFile = function(fullFilename) {
         Iced.register();
       }
     }
+    else {
+      configObject = util.parseString(fileContent, extension);
+    }
   }
   catch (e3) {
     throw new Error("Cannot parse config file: '" + fullFilename + "': " + e3);
@@ -933,6 +860,114 @@ util.parseFile = function(fullFilename) {
       original: fileContent,
       parsed: configObject,
     });
+  }
+
+  return configObject;
+};
+
+/**
+ * Parse and return the specied string with the specified format.
+ *
+ * The format determines the parser to use.
+ *
+ * json = File is parsed using JSON.parse()
+ * yaml (or yml) = Parsed with a YAML parser
+ * toml = Parsed with a TOML parser
+ * cson = Parsed with a CSON parser
+ * hjson = Parsed with a HJSON parser
+ * json5 = Parsed with a JSON5 parser
+ * properties = Parsed with the 'properties' node package
+ *
+ * If the file doesn't exist, a null will be returned.  If the file can't be
+ * parsed, an exception will be thrown.
+ *
+ * This method performs synchronous file operations, and should not be called
+ * after synchronous module loading.
+ *
+ * @protected
+ * @method parseString
+ * @param content {string} The full content
+ * @param format {string} The format to be parsed
+ * @return {configObject} The configuration object parsed from the string
+ */
+util.parseString = function (content, format) {
+  // Initialize
+  var configObject = null;
+
+  // Parse the file based on extension
+  if (format === 'yaml' || format === 'yml') {
+    if (!Yaml && !VisionmediaYaml) {
+      // Lazy loading
+      try {
+        // Try to load the better js-yaml module
+        Yaml = require('js-yaml');
+      }
+      catch (e) {
+        try {
+          // If it doesn't exist, load the fallback visionmedia yaml module.
+          VisionmediaYaml = require('yaml');
+        }
+        catch (e) { }
+      }
+    }
+
+    if (Yaml) {
+      configObject = Yaml.load(content);
+    }
+    else if (VisionmediaYaml) {
+      // The yaml library doesn't like strings that have newlines but don't
+      // end in a newline: https://github.com/visionmedia/js-yaml/issues/issue/13
+      content += '\n';
+      configObject = VisionmediaYaml.eval(util.stripYamlComments(content));
+    }
+    else {
+      console.error("No YAML parser loaded.  Suggest adding js-yaml dependency to your package.json file.")
+    }
+  }
+  else if (format == 'json') {
+    // Allow comments in JSON files
+    configObject = JSON.parse(util.stripComments(content));
+  }
+  else if (format == 'json5') {
+
+    if (!JSON5) {
+      JSON5 = require('json5');
+    }
+
+    configObject = JSON5.parse(content);
+
+  } else if (format == 'hjson') {
+
+    if (!HJSON) {
+      HJSON = require('hjson');
+    }
+
+    configObject = HJSON.parse(content);
+
+  } else if (format == 'toml') {
+
+    if(!TOML) {
+      TOML = require('toml');
+    }
+
+    configObject = TOML.parse(content);
+  }
+  else if (format == 'cson') {
+    if (!CSON) {
+      CSON = require('cson');
+    }
+    // Allow comments in CSON files
+    if (typeof CSON.parseSync === 'function') {
+      configObject = CSON.parseSync(util.stripComments(content));
+    } else {
+      configObject = CSON.parse(util.stripComments(content));
+    }
+  }
+  else if (format == 'properties') {
+    if (!PPARSER) {
+      PPARSER = require('properties');
+    }
+    configObject = PPARSER.parse(content, { namespaces: true, variables: true, sections: true });
   }
 
   return configObject;


### PR DESCRIPTION
As mentioned in pull-request https://github.com/lorenwest/node-config/pull/213 this pull request refactors parseFile and extracts string-based format parsing to a second function. Only .js, .coffee and .iced remains in parseFile.
This is needed for a later use.