### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
   "directories": {
     "lib": "./lib"
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "coffee-script": ">=1.7.0",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/