### PR TITLE
fix attachProtoDeep for setModuleDefaults

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -380,11 +380,11 @@ util.watch = function(object, property, handler, depth) {
  * @param defaultProperties {object} - The default module configuration.
  * @return moduleConfig {object} - The module level configuration object.
  */
-util.setModuleDefaults = function(moduleName, defaultProperties) {
+util.setModuleDefaults = function (moduleName, defaultProperties) {
 
   // Copy the properties into a new object
   var t = this,
-      moduleConfig = util.cloneDeep(defaultProperties);
+    moduleConfig = util.cloneDeep(defaultProperties);
 
   // Set module defaults into the first sources element
   if (configSources.length === 0 || configSources[0].name !== 'Module Defaults') {
@@ -396,9 +396,6 @@ util.setModuleDefaults = function(moduleName, defaultProperties) {
   configSources[0].parsed[moduleName] = {};
   util.extendDeep(configSources[0].parsed[moduleName], defaultProperties);
 
-  // Attach handlers & watchers onto the module config object
-  util.attachProtoDeep(moduleConfig);
-
   // Create a top level config for this module if it doesn't exist
   t[moduleName] = t[moduleName] || {};
 
@@ -406,7 +403,17 @@ util.setModuleDefaults = function(moduleName, defaultProperties) {
   util.extendDeep(moduleConfig, t[moduleName]);
 
   // Merge the extended configs without replacing the original
-  return util.extendDeep(t[moduleName], moduleConfig);
+  util.extendDeep(t[moduleName], moduleConfig);
+
+  // reset the mutability check for "config.get" method.
+  // we are not making t[moduleName] immutable immediately,
+  // since there might be more modifications before the first config.get
+  if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
+    checkMutability = true; 
+  }
+  
+  // Attach handlers & watchers onto the module config object
+  return util.attachProtoDeep(t[moduleName]);
 };
 
 /**

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -298,7 +298,11 @@ vows.describe('Test suite for node-config')
 
       // Set some parameters for the test module
       return CONFIG.util.setModuleDefaults("TestModule", {
-        parm1: 1000, parm2: 2000, parm3: 3000
+        parm1: 1000, parm2: 2000, parm3: 3000,
+        nested: {
+          param4: 4000,
+          param5: 5000
+        }
       });
     },
 
@@ -317,6 +321,22 @@ vows.describe('Test suite for node-config')
 
     'Defaults remain intact unless overridden': function(moduleConfig) {
       assert.equal(moduleConfig.parm2, 2000);
+    },
+
+    'Prototypes are applied by setModuleDefaults even if no previous config exists for the module': function() {
+      var BKTestModuleDefaults = {
+        parm1: 1000, parm2: 2000, parm3: 3000,
+        nested: {
+          param4: 4000,
+          param5: 5000
+        }
+      };
+
+      CONFIG.util.setModuleDefaults("BKTestModule", BKTestModuleDefaults);
+
+      var testModuleConfig = CONFIG.get('BKTestModule');
+
+      assert.deepEqual(BKTestModuleDefaults.nested, testModuleConfig.get('nested'));
     }
   },
 })


### PR DESCRIPTION
setModuleDefaults wouldn't apply the config prototype functions (like `.get()`) to the modules config in the case that no other configuration was provided for this module.  
Also resetting the `checkMutability` flag according to initParam `ALLOW_CONFIG_MUTATIONS`, since the setModuleDefaults function could have been called after the first config.get and then would expose the defaults mutable.