### PR TITLE
More robust handling of JSON

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -947,8 +947,7 @@ util.parseString = function (content, format) {
     }
   }
   else if (format === 'json') {
-    // Allow comments in JSON files
-    configObject = JSON.parse(util.stripComments(content));
+    configObject = JSON.parse(content);
   }
   else if (format === 'json5') {
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -947,7 +947,22 @@ util.parseString = function (content, format) {
     }
   }
   else if (format === 'json') {
-    configObject = JSON.parse(content);
+    try {
+      configObject = JSON.parse(content);
+    }
+    catch (e) {
+      // All JS Style comments will begin with /, so all JSON parse errors that
+      // encountered a syntax error will complain about this character.
+      if (e.name !== 'SyntaxError' || e.message !== 'Unexpected token /') {
+        throw e;
+      }
+
+      if (!JSON5) {
+        JSON5 = require('json5');
+      }
+
+      configObject = JSON5.parse(content);
+    }
   }
   else if (format === 'json5') {
 

--- a/package.json
+++ b/package.json
@@ -18,13 +18,14 @@
     "lib": "./lib"
   },
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "json5": "0.4.0"
+  },
   "devDependencies": {
     "coffee-script": ">=1.7.0",
     "cson": "^3.0.1",
     "hjson": "^1.2.0",
     "js-yaml": "^3.2.2",
-    "json5": "~0.2.0",
     "properties": "~1.2.1",
     "toml": "^2.0.6",
     "vows": ">=0.8.1"

--- a/test/config/custom-environment-variables.json
+++ b/test/config/custom-environment-variables.json
@@ -1,4 +1,5 @@
 {
+  // With a comment
   "customEnvironmentVariables": {
     "mappedBy": {
       "json": "CUSTOM_JSON_ENVIRONMENT_VAR"


### PR DESCRIPTION
This appears to have been added in #1 but it actually causes problems with the module due to the way the data is mutated with regular expressions.

I would like to have this removed because:

1. Comments in straight JSON are not valid according to the spec
2. node-config already supports JSON5, so if comments are required users can use that file format instead.

The case where this breaks is when a JSON file has all of its whitespace removed, for example, consider this original config file:

```json
{
  "version": "v3.1",
  "supportedVersions": [
    "v3",
    "v3.1"
  ],
  "supportedExt": [
    "bulk"
  ],
  "publicRoot": "http://localhost:3000",
  "port": 3000,
  "processes": 0,
  "killTimeout": 10000,
  "api": {
    "host": "",
    "options": {}
  },
  "redis": {
    "host": "127.0.0.1",
    "options": {}
  }
}
```

Now suppose we remove whitespace, e.g.

```javascript
fs.writeFileSync('./config/default.json', JSON.stringify({
  "version": "v3.1",
  "supportedVersions": [
    "v3",
    "v3.1"
  ],
  "supportedExt": [
    "bulk"
  ],
  "publicRoot": "http://localhost:3000",
  "port": 3000,
  "processes": 0,
  "killTimeout": 10000,
  "api": {
    "host": "",
    "options": {}
  },
  "redis": {
    "host": "127.0.0.1",
    "options": {}
  }
}));
```

The resulting file will look like this:

```json
{"version":"v3.1","supportedVersions":["v3","v3.1"],"supportedExt":["bulk"],"publicRoot":"http://localhost:3000","port":3000,"processes":0,"killTimeout":10000,"api":{"host":"","options":{}},"redis":{"host":"127.0.0.1","options":{}}}
```

This is still valid JSON; however, node-config's `util.stripComments` results in the following string:

```
{"version":"v3.1","supportedVersions":["v3","v3.1"],"supportedExt":["bulk"],"publicRoot":"http://localhost:3000","port":3000,"processes":0,"killTimeout":10000,"api":{"host":"","options":{}},"redis":{"hostundefined.0.0.1","options":{}}}
```

which is no longer valid JSON.