### PR TITLE
Correctly handle parsing of inline JSON

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -947,8 +947,7 @@ util.parseString = function (content, format) {
     }
   }
   else if (format === 'json') {
-    // Allow comments in JSON files
-    configObject = JSON.parse(util.stripComments(content));
+    configObject = JSON.parse(util.stripJSONComments(content));
   }
   else if (format === 'json5') {
 
@@ -1423,6 +1422,21 @@ util.stripYamlComments = function(fileStr) {
 }
 
 /**
+ * Strip all Javascript type comments from JSON strings.
+ *
+ * This method will call util.stripComments but has a simplified regex that
+ * will work with JSON strings.
+ *
+ * @protected
+ * @method stripJSONComments
+ * @param fileString {string} The string to strip comments from
+ * @return {string} The string with comments stripped.
+ */
+util.stripJSONComments = function(fileStr) {
+  return util.stripComments(fileStr, /("[^"]*")/g);
+};
+
+/**
  * Strip all Javascript type comments from the string.
  *
  * The string is usually a file loaded from the O/S, containing
@@ -1434,9 +1448,11 @@ util.stripYamlComments = function(fileStr) {
  * @protected
  * @method stripComments
  * @param fileString {string} The string to strip comments from
+ * @param stringRegex {RegExp} Optional regular expression to match strings
  * @return {string} The string with comments stripped.
  */
-util.stripComments = function(fileStr) {
+util.stripComments = function(fileStr, stringRegex) {
+  stringRegex = stringRegex || /(['"])(\\\1|.)+?\1/g;
 
   var uid = '_' + +new Date(),
       primitives = [],
@@ -1446,7 +1462,7 @@ util.stripComments = function(fileStr) {
     fileStr
 
     /* Remove strings */
-    .replace(/(['"])(\\\1|.)+?\1/g, function(match){
+    .replace(stringRegex, function(match){
       primitives[primIndex] = match;
       return (uid + '') + primIndex++;
     })

--- a/lib/config.js
+++ b/lib/config.js
@@ -947,6 +947,7 @@ util.parseString = function (content, format) {
     }
   }
   else if (format === 'json') {
+    // Allow comments in JSON files
     configObject = JSON.parse(util.stripJSONComments(content));
   }
   else if (format === 'json5') {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1434,6 +1434,8 @@ util.stripYamlComments = function(fileStr) {
  * @return {string} The string with comments stripped.
  */
 util.stripJSONComments = function(fileStr) {
+  // Because we are stripping comments from JSON we are only concerned with
+  // strings that begin and end with a double quote.
   return util.stripComments(fileStr, /("[^"]*")/g);
 };
 
@@ -1449,7 +1451,8 @@ util.stripJSONComments = function(fileStr) {
  * @protected
  * @method stripComments
  * @param fileString {string} The string to strip comments from
- * @param stringRegex {RegExp} Optional regular expression to match strings
+ * @param stringRegex {RegExp} Optional regular expression to match strings that
+ *   make up the config file
  * @return {string} The string with comments stripped.
  */
 util.stripComments = function(fileStr, stringRegex) {

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -57,6 +57,8 @@ vows.describe('Test suite for node-config')
 
     'Loading configurations from a JSON file is correct': function() {
       assert.equal(CONFIG.AnotherModule.parm1, 'value1');
+      assert.equal(CONFIG.Inline.a, '');
+      assert.equal(CONFIG.Inline.b, '1');
     },
 
     'Loading configurations from a .yaml YAML file is correct': function() {

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -59,6 +59,7 @@ vows.describe('Test suite for node-config')
       assert.equal(CONFIG.AnotherModule.parm1, 'value1');
       assert.equal(CONFIG.Inline.a, '');
       assert.equal(CONFIG.Inline.b, '1');
+      assert.equal(CONFIG.ContainsQuote, '"this has a quote"');
     },
 
     'Loading configurations from a .yaml YAML file is correct': function() {

--- a/test/config/default.json
+++ b/test/config/default.json
@@ -8,5 +8,7 @@
   "AnotherModule": {
     "parm1":"value1"
   },
-  "staticArray": [2,1,3]
+  "staticArray": [2,1,3],
+  // Some comment
+  "Inline": {"a": "", "b": "1"}
 }

--- a/test/config/default.json
+++ b/test/config/default.json
@@ -10,5 +10,6 @@
   },
   "staticArray": [2,1,3],
   // Some comment
-  "Inline": {"a": "", "b": "1"}
+  "Inline": {"a": "", "b": "1"},
+  "ContainsQuote": "\"this has a quote\""
 }


### PR DESCRIPTION
This arose becasue of the way comments are stripped from JSON. As comments will remain supported in node-config (#256) this change will correctly handle parsing JSON strings regardless of whether or not a comment is encountered.