### PR TITLE
Fix nested quotes with support for empty strings

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1436,7 +1436,7 @@ util.stripYamlComments = function(fileStr) {
 util.stripJSONComments = function(fileStr) {
   // Because we are stripping comments from JSON we are only concerned with
   // strings that begin and end with a double quote.
-  return util.stripComments(fileStr, /("[^"]*")/g);
+  return util.stripComments(fileStr, /(""|("(\\"|.)+?"))/g);
 };
 
 /**


### PR DESCRIPTION
So it turns out the problem in #258 wasn't so much inline JSON as JSON with empty strings. This _should_ fix those problems, but again all regex based solutions are going to have corner cases.

Fixes #259