### PR TITLE
Resolve defered values in predictable order for consistent results. Fixes #265

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -747,28 +747,39 @@ util.loadFileConfigs = function() {
 
 // Using basic recursion pattern, find all the deferred values and resolve them.
 util.resolveDeferredConfigs = function (config) {
-    var completeConfig = config;
+  var completeConfig = config;
 
-    function _iterate (prop) {
-      for (var property in prop) {
-          if (prop.hasOwnProperty(property) && prop[property] != null) {
-              if (prop[property].constructor == Object) {
-                  _iterate(prop[property]);
-              } else if (prop[property].constructor == Array) {
-                  for (var i = 0; i < prop[property].length; i++) {
-                      _iterate(prop[property][i]);
-                  }
-              } else {
-                  if (prop[property] instanceof DeferredConfig ) {
-                    prop[property]= prop[property].resolve.call(completeConfig,completeConfig)
-                  }
-                  else {
-                    // Nothing to do. Keep the property how it is.
-                  }
-              }
-          }
+
+  function _iterate (prop) {
+
+    // We put the properties we are going to look it in an array to keep the order predictable
+    var propsToSort = [];
+
+    // First step is to put the properties of interest in an array
+    for (var property in prop) {
+      if (prop.hasOwnProperty(property) && prop[property] != null) {
+        propsToSort.push(property);
       }
     }
+
+    // Second step is to iterate of the elements in a predictable (sorted) order
+    propsToSort.sort().forEach(function (property) {
+      if (prop[property].constructor == Object) {
+        _iterate(prop[property]);
+      } else if (prop[property].constructor == Array) {
+        for (var i = 0; i < prop[property].length; i++) {
+          _iterate(prop[property][i]);
+        }
+      } else {
+        if (prop[property] instanceof DeferredConfig ) {
+          prop[property]= prop[property].resolve.call(completeConfig,completeConfig)
+        }
+        else {
+          // Nothing to do. Keep the property how it is.
+        }
+      }
+    });
+  }
 
     _iterate(config);
 }


### PR DESCRIPTION
Before, we used the `for..in..` construction to iterate over object
properties, which returns the keys in an arbitrary order which is
usually-but-not-always the key insertion order.

Now object keys are traversed in the order returned by calling sort() on
the key names

Having a predictable resolution order could be useful if you want one
defered value to refer to another defered value. Now one should reliably
resolve before the other.

The change passes all the regression tests. No new test coverage was added. Due to the nature, it was unclear how to test the case of the resolution order being unpredictable in different JavaScript environments.

It's possible that the change could cause someone's code somewhere to break, if they were depending on the old, arbitrary resolution order, which happened to be reliable for them.  However, it could be argued it was a bug in their code to depend on the resolution order, when no resolution order was documented.