### PR TITLE
Allow specifying a default value to get().

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ The following examples are in JSON format, but configurations can be in other [f
       ...
     }
 
-`config.get()` will throw an exception for undefined keys to help catch typos and missing values.
+**Default values:**
+
+    var config = require('config');
+    ...
+    app.listen(config.get('server.port', 9000));
+
+`config.get()` will throw an exception for undefined keys to help catch typos and missing values unless a second, `defaultValue` argument is specified, in which case, the default value will be returned instead.
 Use `config.has()` to test if a configuration value is defined.
 
 **Start your app server:**
@@ -119,6 +125,5 @@ License
 
 May be freely distributed under the [MIT license](https://raw.githubusercontent.com/lorenwest/node-config/master/LICENSE).
 
-Copyright (c) 2010-2015 Loren West 
+Copyright (c) 2010-2015 Loren West
 [and other contributors](https://github.com/lorenwest/node-config/graphs/contributors)
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -157,15 +157,17 @@ var getImpl= function(object, property) {
  *
  * <p>
  * This will return the specified property value, throwing an exception if the
- * configuration isn't defined.  It is used to assure configurations are defined
+ * configuration isn't defined unless `defaultValue`. is specified
+ * It is used to assure configurations are defined
  * before being used, and to prevent typos.
  * </p>
  *
  * @method get
  * @param property {string} - The configuration property to get. Can include '.' sub-properties.
+ * @param defaultValue {object} (optional) - Default value to return if the property can't be found.
  * @return value {mixed} - The property value
  */
-Config.prototype.get = function(property) {
+Config.prototype.get = function(property, defaultValue) {
   if(property === null || property === undefined){
     throw new Error("Calling config.get with null or undefined argument");
   }
@@ -174,7 +176,11 @@ Config.prototype.get = function(property) {
 
   // Produce an exception if the property doesn't exist
   if (value === undefined) {
-    throw new Error('Configuration property "' + property + '" is not defined');
+    if(defaultValue !== undefined) {
+      return defaultValue;
+    } else {
+      throw new Error('Configuration property "' + property + '" is not defined');
+    }
   }
 
   // Make configurations immutable after first get (unless disabled)
@@ -409,9 +415,9 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   // we are not making t[moduleName] immutable immediately,
   // since there might be more modifications before the first config.get
   if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-    checkMutability = true; 
+    checkMutability = true;
   }
-  
+
   // Attach handlers & watchers onto the module config object
   return util.attachProtoDeep(t[moduleName]);
 };

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -246,6 +246,9 @@ vows.describe('Test suite for node-config')
           /Configuration property "Testmodule.misspelled" is not defined/
       );
     },
+    'The default value is returned if specified': function() {
+      assert.equal(CONFIG.Customers.get('non.existant', null), null);
+    },
     'get(undefined) throws an exception': function() {
       assert.throws(
           function () { CONFIG.get(undefined); },
@@ -352,4 +355,3 @@ function requireUncached(module){
    delete require.cache[require.resolve(module)];
    return require(module);
 }
-


### PR DESCRIPTION
In some cases, having to test with `has()` before a get is quite cumbersome. If you're going to specify a default value if `has()` returns false, it would be easier to simply provide it to `get()`.