### PR TITLE
 NODE_APP_INSTANCE changed to NODE_CONFIG_APP_INSTANCE to avoid conflicts with PM2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .project
 node_modules
+.idea/

--- a/lib/config.js
+++ b/lib/config.js
@@ -613,7 +613,7 @@ util.getConfigSources = function() {
  * </p>
  *
  * <p>
- * If the $NODE_APP_INSTANCE environment variable (or --NODE_APP_INSTANCE
+ * If the $NODE_CONFIG_APP_INSTANCE environment variable (or --NODE_CONFIG_APP_INSTANCE
  * command line parameter) is set, then files with this appendage will be loaded.
  * See the Multiple Application Instances section of the main documentaion page
  * for more information.
@@ -635,7 +635,7 @@ util.loadFileConfigs = function() {
   if (CONFIG_DIR.indexOf('.') === 0) {
     CONFIG_DIR = Path.join(process.cwd() , CONFIG_DIR);
   }
-  APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
+  APP_INSTANCE = util.initParam('NODE_CONFIG_APP_INSTANCE');
   HOST = util.initParam('HOST');
   HOSTNAME = util.initParam('HOSTNAME');
 
@@ -1610,7 +1610,7 @@ util.getRegExpFlags = function (re) {
   return flags;
 };
 
-// Run strictness checks on NODE_ENV and NODE_APP_INSTANCE and throw an error if there's a problem.
+// Run strictness checks on NODE_ENV and NODE_CONFIG_APP_INSTANCE and throw an error if there's a problem.
 util.runStrictnessChecks = function (config) {
   var sources = config.util.getConfigSources();
 
@@ -1628,12 +1628,12 @@ util.runStrictnessChecks = function (config) {
     _warnOrThrow("NODE_ENV value of '"+NODE_ENV+"' did not match any deployment config file names.");
   }
 
-  // Throw an exception if there's no explict config file for NODE_APP_INSTANCE
+  // Throw an exception if there's no explict config file for NODE_CONFIG_APP_INSTANCE
   var anyFilesMatchInstance = sourceFilenames.some(function (filename) {
       return filename.match(APP_INSTANCE);
   });
   if (APP_INSTANCE && !anyFilesMatchInstance) {
-    _warnOrThrow("NODE_APP_INSTANCE value of '"+APP_INSTANCE+"' did not match any instance config file names.");
+    _warnOrThrow("NODE_CONFIG_APP_INSTANCE value of '"+APP_INSTANCE+"' did not match any instance config file names.");
   }
 
   // Throw if NODE_ENV matches' default' or 'local'

--- a/test/1-protected-test.js
+++ b/test/1-protected-test.js
@@ -34,7 +34,7 @@ vows.describe('Protected (hackable) utilities test')
       process.env.NODE_ENV='test';
 
       // Test for multi-instance applications
-      process.env.NODE_APP_INSTANCE='3';
+      process.env.NODE_CONFIG_APP_INSTANCE='3';
 
       // Test $NODE_CONFIG environment and --NODE_CONFIG command line parameter
       process.env.NODE_CONFIG='{"EnvOverride":{"parm3":"overridden from $NODE_CONFIG","parm4":100}}';

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -25,7 +25,7 @@ vows.describe('Test suite for node-config')
       process.env.NODE_ENV='test';
 
       // Test for multi-instance applications
-      process.env.NODE_APP_INSTANCE='3';
+      process.env.NODE_CONFIG_APP_INSTANCE='3';
 
       // Test $NODE_CONFIG environment and --NODE_CONFIG command line parameter
       process.env.NODE_CONFIG='{"EnvOverride":{"parm3":"overridden from $NODE_CONFIG","parm4":100}}';

--- a/test/3-deferred-configs.js
+++ b/test/3-deferred-configs.js
@@ -8,7 +8,7 @@ process.env.NODE_CONFIG_DIR = __dirname + '/3-config';
 process.env.NODE_ENV='test';
 
 // Test for multi-instance applications
-process.env.NODE_APP_INSTANCE='defer';
+process.env.NODE_CONFIG_APP_INSTANCE='defer';
 
 // Because require'ing config creates and caches a global singleton,
 // We have to invalidate the cache to build new object based on the environment variables above

--- a/test/4-array-merging.js
+++ b/test/4-array-merging.js
@@ -12,7 +12,7 @@ process.env.NODE_CONFIG_DIR = __dirname + '/config';
 process.env.NODE_ENV='test';
 
 // Test for multi-instance applications
-process.env.NODE_APP_INSTANCE='array-merge';
+process.env.NODE_CONFIG_APP_INSTANCE='array-merge';
 
 // Because require'ing config creates and caches a global singleton,
 // We have to invalidate the cache to build new object based on the environment variables above

--- a/test/5-getConfigSources.js
+++ b/test/5-getConfigSources.js
@@ -13,7 +13,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
 
       delete process.env.NODE_ENV;
       process.env.NODE_CONFIG = '{}';
-      delete process.env.NODE_APP_INSTANCE;
+      delete process.env.NODE_CONFIG_APP_INSTANCE;
       process.argv = ["node","path/to/some.js","--NODE_CONFIG='{}'"];
       var config = requireUncached('../lib/config');
       return config.util.getConfigSources();
@@ -37,7 +37,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
 
       delete process.env.NODE_ENV;
       delete process.env.NODE_CONFIG;
-      delete process.env.NODE_APP_INSTANCE;
+      delete process.env.NODE_CONFIG_APP_INSTANCE;
       process.argv = [];
       var config = requireUncached('../lib/config');
       return config.util.getConfigSources();
@@ -61,7 +61,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
 
       process.env.NODE_ENV='test';
       delete process.env.NODE_CONFIG;
-      delete process.env.NODE_APP_INSTANCE;
+      delete process.env.NODE_CONFIG_APP_INSTANCE;
       process.argv = [];
       var config = requireUncached('../lib/config');
       return config.util.getConfigSources();
@@ -84,7 +84,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
 
       process.env.NODE_ENV='empty';
       delete process.env.NODE_CONFIG;
-      delete process.env.NODE_APP_INSTANCE;
+      delete process.env.NODE_CONFIG_APP_INSTANCE;
       process.argv = [];
       var config = requireUncached('../lib/config');
       return config.util.getConfigSources();

--- a/test/6-strict-mode.js
+++ b/test/6-strict-mode.js
@@ -4,7 +4,7 @@ var vows = require('vows'),
 
 vows.describe('Tests for strict mode').addBatch({
 
-  "Specifying an unused NODE_ENV value and valid NODE_APP_INSTANCE value throws an exception": _expectException({
+  "Specifying an unused NODE_ENV value and valid NODE_CONFIG_APP_INSTANCE value throws an exception": _expectException({
     NODE_ENV         : 'BOOM',
     APP_INSTANCE     : 'valid-instance',
     exceptionMessage : "FATAL: NODE_ENV value of 'BOOM' did not match any deployment config file names. "
@@ -19,10 +19,10 @@ vows.describe('Tests for strict mode').addBatch({
     exceptionMessage : null,
   }),
 
-  "Specifying an unused NODE_APP_INSTANCE and valid NODE_ENV value throws an exception": _expectException({
+  "Specifying an unused NODE_CONFIG_APP_INSTANCE and valid NODE_ENV value throws an exception": _expectException({
     NODE_ENV         : 'valid-deployment',
     APP_INSTANCE     : 'BOOM',
-    exceptionMessage : "FATAL: NODE_APP_INSTANCE value of 'BOOM' did not match any instance config file names. "
+    exceptionMessage : "FATAL: NODE_CONFIG_APP_INSTANCE value of 'BOOM' did not match any instance config file names. "
                      + "See https://github.com/lorenwest/node-config/wiki/Strict-Mode",
   }),
 
@@ -51,7 +51,7 @@ function _expectException (opts) {
       // Change the configuration directory for testing
       process.env.NODE_CONFIG_DIR         = __dirname + '/6-config';
       process.env.NODE_CONFIG_STRICT_MODE = 1;
-      process.env.NODE_APP_INSTANCE       = opts.APP_INSTANCE;
+      process.env.NODE_CONFIG_APP_INSTANCE       = opts.APP_INSTANCE;
       process.env.NODE_ENV                = opts.NODE_ENV;
       delete process.env.NODE_CONFIG;
       try { 

--- a/test/7-unicode-situations.js
+++ b/test/7-unicode-situations.js
@@ -18,7 +18,7 @@ vows.describe('Tests for Unicode situations')
             process.env.NODE_ENV = 'test';
 
             // Test for multi-instance applications
-            process.env.NODE_APP_INSTANCE = '7';
+            process.env.NODE_CONFIG_APP_INSTANCE = '7';
 
             // Test $NODE_CONFIG environment and --NODE_CONFIG command line parameter
             process.env.NODE_CONFIG = '{"EnvOverride":{"parm3":"overridden from $NODE_CONFIG","parm4":100}}';


### PR DESCRIPTION
PM2 uses the env variable NODE_APP_INSTANCE to manage instances in cluster mode, so projects that uses node-config will fail trying to load default-0.json....default-n.json files.