### PR TITLE
Handle null subobject case

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -145,7 +145,8 @@ var getImpl= function(object, property) {
   if (elems.length <= 1) {
     return value;
   }
-  if (typeof value !== 'object') {
+  // Note that typeof null === 'object'
+  if (value === null || typeof value !== 'object') {
     return undefined;
   }
   return getImpl(value, elems.slice(1));

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -276,6 +276,10 @@ vows.describe('Test suite for node-config')
     'A sub level item can be tested': function() {
       assert.isTrue(CONFIG.has('Customers.dbHost'));
     },
+    'A missing sub level item can be tested': function() {
+      assert.isTrue(CONFIG.has('Customers.emptySub'));
+      assert.isFalse(CONFIG.has('Customers.emptySub.foo'));
+    },
     'has is attached deeply': function() {
       assert.isTrue(CONFIG.Customers.has('dbHost'));
     },

--- a/test/config/default.yaml
+++ b/test/config/default.yaml
@@ -3,6 +3,8 @@
 Customers:
   dbPort: 5984
   dbName: from_default_yaml
+  emptySub:
+    # empty
 
 AnotherModule:
   parm2: value2


### PR DESCRIPTION
With Yaml, an empty subobject becomes `null`, and `typeof null` is `object` which makes getImpl descend into it.

Test fails without config.js change and passes with.