### PR TITLE
Read submodule defaults from their own config directory

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -483,9 +483,9 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   // we are not making t[moduleName] immutable immediately,
   // since there might be more modifications before the first config.get
   if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-    checkMutability = true;
+    checkMutability = true; 
   }
-  
+
   // Attach handlers & watchers onto the module config object
   return util.attachProtoDeep(t[moduleName]);
 };
@@ -1767,5 +1767,5 @@ var config = module.exports = new Config();
 var showWarnings = !(util.initParam('SUPPRESS_NO_CONFIG_WARNING'));
 if (showWarnings && Object.keys(config).length === 0) {
   console.error('WARNING: No configurations found in configuration directory:' +CONFIG_DIR);
-  console.error('WARNING: To disable this warning set SUPRESS_NO_CONFIG_WARNING in the environment.');
+  console.error('WARNING: To disable this warning set SUPPRESS_NO_CONFIG_WARNING in the environment.');
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -145,7 +145,7 @@ var getImpl= function(object, property) {
       value;
 
   // If this is being called from a submodule, we have to modify the object being accessed
-  var value = (getCallingFilePath() !== process.cwd() && object[packageName]) ? object[packageName][name] : object[name];
+  var value = (callingFileDirectoryPath() !== process.cwd() && object[packageName]) ? object[packageName][name] : object[name];
   if (elems.length <= 1) {
     return value;
   }
@@ -173,9 +173,6 @@ Config.prototype.get = function(property) {
   if(property === null || property === undefined){
     throw new Error("Calling config.get with null or undefined argument");
   }
-  // if (property !== '' && getCallingFilePath() !== process.cwd()) {
-  //   property = getPackageJson().name + '.' + property;
-  // }
   var t = this,
       value = getImpl(t, property);
 
@@ -360,10 +357,10 @@ util.watch = function(object, property, handler, depth) {
  * This is accomplished by making use of an Error callstack.
  *
  * @private
- * @method getCallingFilePath
- * @return value {string} - The absolute filepath to the javascript file calling config
+ * @method callingFileDirectoryPath
+ * @return value {string} - The absolute filepath to the directory containing the javascript file calling config
  */
-var getCallingFilePath = function() {
+var callingFileDirectoryPath = function() {
   try {
     var error = new Error();
     // Prepare the stack trace so that we can shift through it to get the call trace
@@ -403,7 +400,7 @@ var getCallingFilePath = function() {
  * @return object {object} - Object representation of a module's package.json file
  */
 var getPackageJson = function() {
-  var packageJsonFilePath = getCallingFilePath() + '/package.json';
+  var packageJsonFilePath = callingFileDirectoryPath() + '/package.json';
   var packageJson;
   try {
     FileSystem.accessSync(packageJsonFilePath, FileSystem.F_OK);
@@ -449,13 +446,15 @@ var getPackageJson = function() {
  * @return moduleConfig {object} - The module level configuration object.
  */
 util.setModuleDefaults = function (moduleName, defaultProperties) {
+
   // Copy the properties into a new object
   var t = this,
     moduleConfig = util.cloneDeep(defaultProperties);
 
-  // If a module is passed in instead of a string and there are no defaultProperties specified, read config values from that modules /config directory
+  // If a module is passed in instead of a string and there are no defaultProperties
+  // specified, read config values from that module's /config directory
   if (typeof moduleName === 'object' && !defaultProperties) {
-    var moduleFilePath = getCallingFilePath(),
+    var moduleFilePath = callingFileDirectoryPath(),
         packageJson = getPackageJson();
     moduleName = packageJson.name;
     moduleConfig = util.loadFileConfigs();
@@ -702,12 +701,13 @@ util.loadFileConfigs = function() {
 
   // Initialize
   var t = this,
-      config = {};
+      config = {},
+      configDir = callingFileDirectoryPath();
 
   // Initialize parameters from command line, environment, or default
   NODE_ENV = util.initParam('NODE_ENV', 'development');
-  CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', getCallingFilePath() ? getCallingFilePath() + '/config' : Path.join( process.cwd(), 'config') );
-  // CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', getCallingFilePath() + '/config');
+
+  CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', configDir ? Path.join(configDir, 'config') : Path.join( process.cwd(), 'config') );
   if (CONFIG_DIR.indexOf('.') === 0) {
     CONFIG_DIR = Path.join(process.cwd() , CONFIG_DIR);
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -364,6 +364,7 @@ util.watch = function(object, property, handler, depth) {
  * @return value {string} - The absolute filepath to the directory containing the javascript file calling config
  */
 var callingFileDirectoryPath = function() {
+  var originalStackTrace = Error.prepareStackTrace;
   try {
     var error = new Error();
     // Prepare the stack trace so that we can shift through it to get the call trace
@@ -388,10 +389,13 @@ var callingFileDirectoryPath = function() {
         pathSubsections.forEach(function(subsection) {
           finalPath += '/' + subsection;
         });
+        Error.prepareStackTrace = originalStackTrace;
         return finalPath;
       }
     }
   } catch (err) {}
+
+  Error.prepareStackTrace = originalStackTrace;
   return undefined;
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -141,12 +141,15 @@ var getImpl= function(object, property) {
   var t = this,
       elems = Array.isArray(property) ? property : property.split('.'),
       name = elems[0],
-      value = object[name];
+      packageName = getPackageJson().name,
+      value;
+
+  // If this is being called from a submodule, we have to modify the object being accessed
+  var value = (getCallingFilePath() !== process.cwd() && object[packageName]) ? object[packageName][name] : object[name];
   if (elems.length <= 1) {
     return value;
   }
-  // Note that typeof null === 'object'
-  if (value === null || typeof value !== 'object') {
+  if (typeof value !== 'object') {
     return undefined;
   }
   return getImpl(value, elems.slice(1));
@@ -170,6 +173,9 @@ Config.prototype.get = function(property) {
   if(property === null || property === undefined){
     throw new Error("Calling config.get with null or undefined argument");
   }
+  // if (property !== '' && getCallingFilePath() !== process.cwd()) {
+  //   property = getPackageJson().name + '.' + property;
+  // }
   var t = this,
       value = getImpl(t, property);
 
@@ -349,6 +355,67 @@ util.watch = function(object, property, handler, depth) {
 };
 
 /**
+ * Finds the filepath of the current file making use of config.
+ *
+ * This is accomplished by making use of an Error callstack.
+ *
+ * @private
+ * @method getCallingFilePath
+ * @return value {string} - The absolute filepath to the javascript file calling config
+ */
+var getCallingFilePath = function() {
+  try {
+    var error = new Error();
+    // Prepare the stack trace so that we can shift through it to get the call trace
+    Error.prepareStackTrace = function (error, stack) { return stack; };
+
+    // Grab the currentFile we're in
+    var currentFile = error.stack.shift().getFileName();
+
+    // For every call in the stack trace
+    while (error.stack.length) {
+      // Grab the next call down the trace
+      var callingFile = error.stack.shift().getFileName();
+      // Make sure the call didn't originate from the same file, ignore those
+      if (currentFile != callingFile) {
+        var pathSubsections = callingFile.split('/');
+        // Pop off the empty string at the front
+        pathSubsections.shift();
+        // Remove the calling filename, we just want the directory it's in
+        pathSubsections.pop();
+        var finalPath = '';
+        // Rebuild the array into a single string
+        pathSubsections.forEach(function(subsection) {
+          finalPath += '/' + subsection;
+        });
+        return finalPath;
+      }
+    }
+  } catch (err) {}
+  return undefined;
+}
+
+/**
+ * Grabs the package.json object of the file that is currently calling config.
+ *
+ * @private
+ * @method getPackageJson
+ * @return object {object} - Object representation of a module's package.json file
+ */
+var getPackageJson = function() {
+  var packageJsonFilePath = getCallingFilePath() + '/package.json';
+  var packageJson;
+  try {
+    FileSystem.accessSync(packageJsonFilePath, FileSystem.F_OK);
+    packageJson = JSON.parse(FileSystem.readFileSync(packageJsonFilePath));
+  } catch (e) {
+    // If the calling directory doensn't have a valid package.json, mark it as such
+    packageJson = {'name': 'invalid-package-json'};
+  }
+  return packageJson;
+}
+
+/**
  * <p>
  * Set default configurations for a node.js module.
  * </p>
@@ -382,10 +449,17 @@ util.watch = function(object, property, handler, depth) {
  * @return moduleConfig {object} - The module level configuration object.
  */
 util.setModuleDefaults = function (moduleName, defaultProperties) {
-
   // Copy the properties into a new object
   var t = this,
     moduleConfig = util.cloneDeep(defaultProperties);
+
+  // If a module is passed in instead of a string and there are no defaultProperties specified, read config values from that modules /config directory
+  if (typeof moduleName === 'object' && !defaultProperties) {
+    var moduleFilePath = getCallingFilePath(),
+        packageJson = getPackageJson();
+    moduleName = packageJson.name;
+    moduleConfig = util.loadFileConfigs();
+  }
 
   // Set module defaults into the first sources element
   if (configSources.length === 0 || configSources[0].name !== 'Module Defaults') {
@@ -410,9 +484,9 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   // we are not making t[moduleName] immutable immediately,
   // since there might be more modifications before the first config.get
   if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-    checkMutability = true; 
+    checkMutability = true;
   }
-  
+
   // Attach handlers & watchers onto the module config object
   return util.attachProtoDeep(t[moduleName]);
 };
@@ -632,7 +706,8 @@ util.loadFileConfigs = function() {
 
   // Initialize parameters from command line, environment, or default
   NODE_ENV = util.initParam('NODE_ENV', 'development');
-  CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
+  CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', getCallingFilePath() ? getCallingFilePath() + '/config' : Path.join( process.cwd(), 'config') );
+  // CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', getCallingFilePath() + '/config');
   if (CONFIG_DIR.indexOf('.') === 0) {
     CONFIG_DIR = Path.join(process.cwd() , CONFIG_DIR);
   }
@@ -1692,5 +1767,5 @@ var config = module.exports = new Config();
 var showWarnings = !(util.initParam('SUPPRESS_NO_CONFIG_WARNING'));
 if (showWarnings && Object.keys(config).length === 0) {
   console.error('WARNING: No configurations found in configuration directory:' +CONFIG_DIR);
-  console.error('WARNING: To disable this warning set SUPPRESS_NO_CONFIG_WARNING in the environment.');
+  console.error('WARNING: To disable this warning set SUPRESS_NO_CONFIG_WARNING in the environment.');
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -138,6 +138,9 @@ var util = Config.prototype.util = {};
  * @return value {mixed} - Property value, including undefined if not defined.
  */
 var getImpl= function(object, property) {
+  // Check for null to acquiesce tests for checking has() on a null object
+  if (object === null) return undefined;
+
   var t = this,
       elems = Array.isArray(property) ? property : property.split('.'),
       name = elems[0],
@@ -483,7 +486,7 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   // we are not making t[moduleName] immutable immediately,
   // since there might be more modifications before the first config.get
   if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-    checkMutability = true; 
+    checkMutability = true;
   }
 
   // Attach handlers & watchers onto the module config object

--- a/lib/config.js
+++ b/lib/config.js
@@ -485,7 +485,7 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
     checkMutability = true;
   }
-
+  
   // Attach handlers & watchers onto the module config object
   return util.attachProtoDeep(t[moduleName]);
 };


### PR DESCRIPTION
This pull request is in reference to https://github.com/lorenwest/node-config/issues/225.

This fix allows for submodules to use a single arg version of `util.setModuleDefaults()`. If utilized, config will load in the submodules configuration values from the submodules `/config` directory and name them based on the name of the submodule pulled from it's `package.json` to avoid naming conflicts.

As a result, this led to also changing the `getImpl()` function to first grab configuration values from a submodule object if it exists, and if the submodule object does not exist, just uses the top level configuration object as normal.

Values can still be overridden from the top level `/config` directory as normal. It also allows for submodules to be run as an individual apps for testing purposes, since at that point it will recognize it's own config directory as the top level config directory.
