### PR TITLE
Feature to search parent config path

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -410,9 +410,9 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   // we are not making t[moduleName] immutable immediately,
   // since there might be more modifications before the first config.get
   if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-    checkMutability = true; 
+    checkMutability = true;
   }
-  
+
   // Attach handlers & watchers onto the module config object
   return util.attachProtoDeep(t[moduleName]);
 };
@@ -626,13 +626,27 @@ util.getConfigSources = function() {
  */
 util.loadFileConfigs = function() {
 
+  // Search for config directory in a paths lists
+  var findConfigDirectory = function (paths) {
+    if (!paths.length) return null;
+    try {
+      var currentPath = paths[0].replace(/node_modules$/, 'config');
+      if (FileSystem.lstatSync(currentPath).isDirectory()) {
+        return currentPath;
+      }
+    } catch (e) {
+        return findConfigDirectory(paths.splice(1));
+    }
+  };
+  
   // Initialize
   var t = this,
-      config = {};
+      config = {},
+      configDirectory = process.env.NODE_CONFIG_DIR || findConfigDirectory(module.parent.paths) || Path.join( process.cwd(), 'config');
 
   // Initialize parameters from command line, environment, or default
   NODE_ENV = util.initParam('NODE_ENV', 'development');
-  CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
+  CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', configDirectory);
   if (CONFIG_DIR.indexOf('.') === 0) {
     CONFIG_DIR = Path.join(process.cwd() , CONFIG_DIR);
   }

--- a/test/7-unicode-situations.js
+++ b/test/7-unicode-situations.js
@@ -71,4 +71,3 @@ function requireUncached(module) {
     delete require.cache[require.resolve(module)];
     return require(module);
 }
-

--- a/test/8-config/config/default.json
+++ b/test/8-config/config/default.json
@@ -1,0 +1,3 @@
+{
+  "project" : "A project must use node-config"
+}

--- a/test/8-config/level-1/level-2/config/default.json
+++ b/test/8-config/level-1/level-2/config/default.json
@@ -1,0 +1,3 @@
+{
+  "betterProject" : "A better project must enforce node-config"
+}

--- a/test/8-config/level-1/level-2/level-3/mock.js
+++ b/test/8-config/level-1/level-2/level-3/mock.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  return require('../../../../../lib/config');
+}

--- a/test/8-parent-resolve.js
+++ b/test/8-parent-resolve.js
@@ -1,0 +1,59 @@
+
+
+// Dependencies
+var vows   = require('vows'),
+    assert = require('assert'),
+    Path   = require('path');
+
+vows.describe('Tests for loading config by parent chain resolution').addBatch({
+  'fetch config from direct parent chain': {
+    topic: function () {
+      // Remove configuration directory
+      delete process.env.NODE_CONFIG_DIR;
+      delete process.env.NODE_ENV;
+      process.env.NODE_CONFIG = '{ "test": "Hello" }';
+      delete process.env.NODE_APP_INSTANCE;
+
+      removeCache('../lib/config');
+
+      // Ask submodule to load config module
+      return require('./8-config/level-1/level-2/level-3/mock')();
+    },
+
+    'Config is loaded by merging immediate parent and NODE_CONFIG environment variable': function (topic) {
+      assert.equal(topic.get('betterProject'), 'A better project must enforce node-config');
+      assert.equal(topic.get('test'), 'Hello');
+      assert.equal(topic.has('project'), false);
+    },
+
+  },
+  'prefer NODE_CONFIG_DIR over parent chain': {
+    topic: function () {
+      // Remove configuration directory
+      process.env.NODE_CONFIG_DIR = __dirname + '/8-config/config';
+      delete process.env.NODE_ENV;
+      process.env.NODE_CONFIG = '{ "test": "Hello" }';
+      delete process.env.NODE_APP_INSTANCE;
+
+      removeCache('../lib/config');
+
+      // Ask submodule to load config module
+      return require('./8-config/level-1/level-2/level-3/mock')();
+    },
+
+    'Config is loaded by merging NODE_CONFIG_DIR config and NODE_CONFIG environment variable': function (topic) {
+      assert.equal(topic.has('betterProject'), false);
+      assert.equal(topic.get('test'), 'Hello');
+      assert.equal(topic.get('project'), 'A project must use node-config');
+    },
+
+  }
+})
+.export(module);
+
+//
+// Because require'ing config creates and caches a global singleton,
+// We have to invalidate the cache to build new object based on the environment variables above
+function removeCache(module){
+   delete require.cache[require.resolve(module)];
+}


### PR DESCRIPTION
Closes #303 

This PR will allow `node-config` to recursively check for parent `config` folder. This will allow sub module to define their own configuration inside their own child `config` folder.

This behavior can be overridden by `NODE_CONFIG_DIR`, so `node-config` will always prefer to `NODE_CONFIG_DIR`, if not set it will lookup for parent `config` folder chain, if no config folder found it will default back to `process.cwd() + '/config'` folder. 

cc @lorenwest 