### PR TITLE
Handle node v6 SyntaxError message containing position data

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -965,7 +965,7 @@ util.parseString = function (content, format) {
     catch (e) {
       // All JS Style comments will begin with /, so all JSON parse errors that
       // encountered a syntax error will complain about this character.
-      if (e.name !== 'SyntaxError' || e.message !== 'Unexpected token /') {
+      if (e.name !== 'SyntaxError' || e.message.indexOf('Unexpected token /') !== 0) {
         throw e;
       }
 


### PR DESCRIPTION
Fix to catch the JSON parse exceptions which have changed in Node v6.
Position info has been appended to the end of the message, so it now looks like "Unexpected token / in JSON at position X"