### PR TITLE
Fixes #266 - implement recursive resolver for deferreds, using getters

### DIFF
--- a/defer.js
+++ b/defer.js
@@ -1,14 +1,122 @@
-// Create a deferredConfig prototype so that we can check for it when reviewing the configs later.
-function DeferredConfig () {
-}
-DeferredConfig.prototype.resolve = function (config) {};
+// See resolver.md for some notes about how this works.
 
-// Accept a function that we'll use to resolve this value later and return a 'deferred' configuration value to resolve it later.
-function deferConfig (func) {
+// Class that wraps special functions that are evaluated after all config 
+// overrides are in place.
+function DeferredConfig () {}
+
+// Users use this function in their JavaScript config files to specify config 
+// values that depend on others. This returns a DeferredConfig object that
+// wraps the function (refered to simply as "the deferred").
+function deferConfig(func) {
   var obj = Object.create(DeferredConfig.prototype);
   obj.resolve = func;
   return obj;
 }
 
-module.exports.deferConfig = deferConfig;
-module.exports.DeferredConfig = DeferredConfig;
+// The main function that resolves the entire config tree, evaluating and
+// replacing all deferreds.
+function resolve(mainConfig) {
+  var main = new Resolver(mainConfig);
+  main.resolve();
+}
+
+// Resolver objects define getters for each of the properties in a config node.
+// The purpose of the Resolver objects is to proxy those nodes, so that they
+// can participate in expressions inside deferred functions.
+// The constructor itself does not recurse; it only defines getters for the 
+// immediate children.
+var Resolver = function(config, main) {
+  var self = this;
+  if (!main) main = self;
+
+  // The enumerable keys of config that we care about
+  var childKeys = Object.keys(config).filter(function(k) {
+    return config.hasOwnProperty(k) && typeof config[k] !== 'undefined';
+  });
+
+  // Create a non-enumerable property, __data__, to hold bookkeeping data
+  var data = {
+    main: main,
+    config: config,
+    childKeys: childKeys,
+  };
+  Object.defineProperty(self, '__data__', {
+    __proto__: null,
+    value: data,
+  });
+
+  // Make the getters.
+  // Contract: for every enumerable property (k, v) of a config node, the getter
+  // returns either the original atom from the config, or a resolver (never an object or a
+  // deferred)
+  var values = {};  // memoize the results
+  childKeys.forEach(function(key) {
+    Object.defineProperty(self, key, {
+      __proto__: null,
+      enumerable: true,
+      configurable: false,
+      get: function() {
+        if (key in values) return values[key];
+        return values[key] = self.newNode(config[key]);
+      }
+    });
+  });
+};
+
+// resolver.newNode() - passes through or creates resolver tree nodes 
+// corresponding to config tree nodes. The `node` argument can be of any type. 
+// This evaluates deferred functions, and wraps config objects in resolvers, as 
+// needed. Contract: the return value is guaranteed to be an atom or a resolver
+Resolver.prototype.newNode = function(node) {
+  var self = this,
+      main = self.__data__.main;
+  var t = nodeType(node);
+  return (t === 'atom') ? node :
+         (t === 'resolver') ? node :
+         // deferreds are evaluated recursively:
+         (t === 'deferred') ? self.newNode(node.resolve.call(main, main)) :
+         new Resolver(node, main);
+};
+
+// resolver.resolve() - recursively resolves all of the data in the config tree.
+// Contract: after this executes, the `config` node corresponding to this 
+// resolver will be an atom or an object tree such that:
+// - there are no deferreds or resolvers anywhere in the tree
+// - every node in the tree is the corresponding original atom or object from 
+//   the config tree (i.e., there are no clones)
+Resolver.prototype.resolve = function() {
+  var self = this,
+      data = self.__data__,
+      config = data.config,
+      childKeys = data.childKeys;
+  childKeys.forEach(function(key) {
+    var v = self[key];      // either an atom or a resolver
+    if (nodeType(v) === 'atom')
+      config[key] = v;
+    else {  // resolver
+      v.resolve();
+      config[key] = v.__data__.config;
+    }
+  });
+};
+
+// There are four main types for the nodes in a configuration tree: atoms, 
+// objects (which include arrays), DeferredConfigs (deferreds, for short), and 
+// resolvers.
+var nodeType = function(node) {
+  if (node instanceof Resolver) return 'resolver';
+  if (typeof node !== 'object' || !node) return 'atom';
+  if (node instanceof Date) return 'atom';
+  // The test for DeferredConfig addresses the concern in this PR (but it's not 
+  // a complete fix): https://github.com/lorenwest/node-config/pull/205.
+  if (node instanceof DeferredConfig ||
+    (('constructor' in node) && (node.constructor.name === 'DeferredConfig')))
+    return 'deferred';
+  return 'object';
+};
+
+module.exports = {
+  deferConfig: deferConfig,
+  DeferredConfig: DeferredConfig,
+  resolve: resolve,
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,6 +15,7 @@ var Yaml = null,    // External libraries are lazy-loaded
     HJSON = null,
     deferConfig = require('../defer').deferConfig,
     DeferredConfig = require('../defer').DeferredConfig,
+    resolve = require('../defer').resolve,
     Utils = require('util'),
     Path = require('path'),
     FileSystem = require('fs');
@@ -746,44 +747,8 @@ util.loadFileConfigs = function() {
   return config;
 };
 
-// Using basic recursion pattern, find all the deferred values and resolve them.
-util.resolveDeferredConfigs = function (config) {
-  var completeConfig = config;
-
-
-  function _iterate (prop) {
-
-    // We put the properties we are going to look it in an array to keep the order predictable
-    var propsToSort = [];
-
-    // First step is to put the properties of interest in an array
-    for (var property in prop) {
-      if (prop.hasOwnProperty(property) && prop[property] != null) {
-        propsToSort.push(property);
-      }
-    }
-
-    // Second step is to iterate of the elements in a predictable (sorted) order
-    propsToSort.sort().forEach(function (property) {
-      if (prop[property].constructor == Object) {
-        _iterate(prop[property]);
-      } else if (prop[property].constructor == Array) {
-        for (var i = 0; i < prop[property].length; i++) {
-          _iterate(prop[property][i]);
-        }
-      } else {
-        if (prop[property] instanceof DeferredConfig ) {
-          prop[property]= prop[property].resolve.call(completeConfig,completeConfig)
-        }
-        else {
-          // Nothing to do. Keep the property how it is.
-        }
-      }
-    });
-  }
-
-    _iterate(config);
-}
+// Resolve all deferreds.
+util.resolveDeferredConfigs = resolve;
 
 /**
  * Parse and return the specified configuration file.

--- a/lib/resolver.md
+++ b/lib/resolver.md
@@ -1,0 +1,120 @@
+# How resolution works.
+
+After all of the config data has been read in and merged, the defer.js module's 
+resolve() method is called. Its task is to recursively walk through the entire 
+heirarchical data tree, and wherever there is a deferred function, to evaluate 
+it, and replace that node in the tree with the return value of the function.
+
+In order to enable other configuration values to be used inside the bodies of 
+deferred functions in such a way that it doesn't depend on the order of 
+evaluation (see 
+[issue #266](https://github.com/lorenwest/node-config/issues/266)) proxy 
+objects are used to represent those config objects during those evaluations.
+
+For example, suppose you have config files with:
+
+```javascript
+// default.js:
+var config = {
+  siteTitle : 'Site title',
+  header :  defer(cfg => 'Welcome to ' + cfg.siteTitle),
+};
+
+// local.js:
+var config = {
+  fadOfTheWeek = 'Big Data',
+  siteTitle : defer(cfg => cfg.fadOfTheWeek + ' Experts!'),
+};
+```
+
+During resolution, the deferred function for `header` is executed. If the 
+value of the `cfg` argument inside that function were the actual config 
+object, then that could cause problems, because the value for `siteTitle` also 
+comes from a deferred. If the `header` function is evaluated first, then the 
+value would be garbled -- it would include the default string representation 
+of the DeferredConfig instance. 
+
+Instead, the value of the `cfg` argument inside the deferred function body is 
+not the actual config object, but an instance of the Resolver class. It has 
+getter functions for each of the properties of the real config object. In the 
+example above, when the `header` deferred is executed, the expression `cfg.
+siteTitle` is evaluated, which causes that getter function to be executed. 
+That function is smart enough to recognize that the value of `siteTitle` comes 
+from a deferred function; so it executes it, and returns the correct result.
+
+This approach is very powerful, and enables complex interdependencies among 
+config variables, without ever having to worry about the time-ordering of the 
+evaluations. Of course, circular references are not allowed.
+So, for example, this wouldn't work:
+
+```javascript
+name: defer(cfg => ({
+  first: 'Robert',
+  nickname: cfg.name.first == 'Robert' ? 'Bob' : 'Bruce',
+})),
+```
+
+At first glance, it might seem that this isn't circular, since `nickname` is 
+referencing a sibling, not itself. However, when evaluating `nickname`, the 
+reference to `cfg.name` must be evaluated first, and it's inside it's own 
+deferred function, which makes it circular. This could be fixed easily, 
+however, using a nested deferred:
+
+```javascript
+name: defer(cfg => ({
+  first: 'Robert',
+  nickname: defer(cfg => cfg.name.first == 'Robert' ? 'Bob' : 'Bruce'),
+})),
+```
+
+To avoid making this mistake, you could adopt the convention that any "leaf" 
+value that depends on other config information should be wrapped in its own 
+deferred function.
+
+
+## Algorithm
+
+During resolution, the software maintains two trees of data:
+
+1. config tree, which is the original config data, that includes atoms, 
+  objects, and deferreds (no resolvers)
+2. resolver tree, which proxies the config tree, and has nodes *only* of type 
+  atom and resolver (no objects or deferreds). The resolver tree nodes are
+  constructed dynamically by the getters, but the tree can be thought of as 
+  static. 
+
+These routines are involved during the resolution process:
+
+***resolve(config)***
+
+The main entry point. This function resolves the entire config tree, 
+evaluating and replacing all deferreds.
+
+It creates a new Resolver object (the "main resolver") from `config` (which is 
+the "main" config, or the root of the config tree) and delegates to its 
+`resolve()` method. Note that this "main resolver" is the object that gets 
+passed in as the `cfg` argument of the deferred functions.
+
+***resolver.resolve()***
+
+This resolves the config subtree corresponding to this resolver. It is a very
+simple recursive process: it iterates over its child nodes, which must be 
+either atoms or resolvers:
+
+* If atom, it is inserted into the config object.
+* If resolver:
+    * Recurse: call its `resolve()` method
+    * Insert this child resolver's config node into our config object 
+
+***resolver getters***
+
+These invoke `.newNode()` to construct new nodes in the resolver tree, and 
+store the results (each node is only created once).
+
+***resolver.newNode()***
+
+The argument to this is a node from either the config tree or the resolver 
+tree (in other words, it can be of any type). If it's an atom or resolver,
+this merely passes it along. If it is a deferred, this executes the deferred 
+recursively, until the return value is something else. If it is an object, 
+then a new Resolver object is created to wrap it, and that is returned.

--- a/test/3-config/default.js
+++ b/test/3-config/default.js
@@ -1,5 +1,6 @@
 
 var defer = require('../../defer').deferConfig;
+var process = require('process');
 
 var config = {
   siteTitle : 'Site title',
@@ -31,5 +32,87 @@ config.map = {
     return { lat: this.latitude, lon: this.longitude };
   }),
 };
+
+config.name = defer(cfg => ({
+  first: 'Robert',
+  nickname: defer(cfg => cfg.name.first == 'Robert' ? 'Bob' : 'Bruce'),
+}));
+
+// Here's one way you could do dependency injection.
+// Define a class to provide the default implementation of a service adapter.
+// At runtime, some other config file could add to the registry, and/or reset the active service.
+var MockServiceAdapter = function() {};
+MockServiceAdapter.prototype.message = 'Mock service for development';
+
+config.service = {
+  registry: {
+    mock: MockServiceAdapter,
+  },
+  name: 'mock',
+  active: defer(cfg => cfg.service.registry[cfg.service.name]),
+};
+
+// "stress test" of the deferred function. Some of this data is here, and some in local.js.
+var stressConfig = {
+  // From issue #231
+  images: {
+    src: 'happy-gardens',
+  },
+  srcSvgGlob: [
+    '/plyr/src/sprite/*.svg',
+    defer(function (cfg) {
+      return cfg.images.src + '/*.svg';
+    })
+  ],
+
+  // For a1 - h2: see local.js
+
+  // deferreds that resolve to trees
+  i0: defer(cfg => ({
+    a: { a: 21, b: 9, },
+    b: [ 9, 'snorky', defer(cfg => cfg.a1)]
+  })),
+
+  // deferreds within deferreds
+  i1: defer(cfg => ({
+    ic: cfg.h1,  // .h1 has a deferred in it
+    id: defer(cfg => defer(cfg => cfg.h1)),
+  })),
+
+  // referencing nested items
+  i2: defer(cfg => ({
+    z: 5,
+    a: { a: cfg.i0.b[1], b: cfg.i0.b[2], },
+    b: [ -2, cfg.i0.b, ],
+    c: defer((cfg) => cfg.i2.b[1][1]),   //=> 'snorky'; references a sibling in the same subtree
+  })),
+
+  // For a2 - e2: see local.js
+
+  // Some more deeply nested deferreds
+  f2: {
+    fa: {
+      a: {
+        a: defer(cfg => cfg.a1),
+      }
+    },
+    fb: {
+      a: [
+        5,
+        'blue',
+        { a: {
+          a: defer(cfg => cfg.c1),
+          b: 'orange',
+        },
+        },
+      ],
+    },
+  },
+};
+
+Object.keys(stressConfig).forEach(function(key) {
+  config[key] = stressConfig[key];
+});
+
 
 module.exports = config;

--- a/test/3-config/local.js
+++ b/test/3-config/local.js
@@ -1,3 +1,4 @@
+var defer = require('../../defer').deferConfig;
 
 var config = {
  siteTitle : 'New Instance!',
@@ -6,5 +7,68 @@ var config = {
 config.map = {
   centerPoint :  { lat: 3, lon: 4 },
 };
+
+var RealServiceAdapter = function() {};
+RealServiceAdapter.prototype.message = 'Real thing';
+config.service = {
+  // Add our service adapter to the regiistry
+  registry: {
+    'real': new RealServiceAdapter()
+  },
+  // Override the active service
+  name: 'real'
+};
+
+var stressConfig = {
+  // From issue #231
+  images: {
+    src: 'foobar',  // override
+  },
+
+  a1: 1,
+  c1: defer(cfg => cfg.a1),
+  d1: defer(cfg => cfg.a1 + cfg.a1),
+  e1: defer(cfg => cfg.a1 + cfg.c1 + cfg.d1),
+  // This one references an item that (perhaps) is evaluated later
+  f1: defer(cfg => cfg.g1 + cfg.a1),
+  g1: defer(cfg => cfg.a1),
+
+  // deferreds in descendants
+  h1: { ha: 5,
+    hb: defer(cfg => cfg.a1 + cfg.e1), },
+  h2: {
+    a: {
+      a: [
+        7, 'fleegle',
+        defer(cfg => cfg.a1 + cfg.e1),
+      ],
+    },
+  },
+
+  // For i0 - i2: see default.js
+
+  a2: 1,
+  b2: defer(cfg => cfg.a2),
+  c2: defer(cfg => [
+    cfg.d2,
+    cfg.e2.e0,
+  ]),
+  d2: defer(cfg => ({
+    d0: 0,
+    d1: 1,
+  })),
+  e2: defer(cfg => ({
+    e0: defer(cfg => [
+      'hello',
+      cfg.b2,
+    ]),
+  })),
+
+  // For f2: see default.js
+};
+
+Object.keys(stressConfig).forEach(function(key) {
+  config[key] = stressConfig[key];
+});
 
 module.exports = config;

--- a/test/3-deferred-configs.js
+++ b/test/3-deferred-configs.js
@@ -18,6 +18,35 @@ var CONFIG = requireUncached('../lib/config');
 var vows = require('vows'),
     assert = require('assert');
 
+// Expected results for deferred stress test
+var expectedStress =  {
+  images: { src: 'foobar' },
+  srcSvgGlob: [ '/plyr/src/sprite/*.svg', 'foobar/*.svg' ],
+  a1: 1,
+  c1: 1,
+  d1: 2,
+  e1: 4,
+  f1: 2,
+  g1: 1,
+  h1: { ha: 5, hb: 5 },
+  h2: { a: { a: [ 7, 'fleegle', 5 ] } },
+  i0: { a: { a: 21, b: 9 }, b: [ 9, 'snorky', 1 ] },
+  i2:
+  { z: 5,
+    a: { a: 'snorky', b: 1 },
+    b: [ -2, [ 9, 'snorky', 1 ] ],
+    c: 'snorky' },
+  i1: { ic: { ha: 5, hb: 5 }, id: { ha: 5, hb: 5 } },
+  a2: 1,
+  b2: 1,
+  c2: [ { d0: 0, d1: 1 }, [ 'hello', 1 ] ],
+  d2: { d0: 0, d1: 1 },
+  e2: { e0: [ 'hello', 1 ] },
+  f2:
+  { fa: { a: { a: 1 } },
+    fb: { a: [ 5, 'blue', { a: { a: 1, b: 'orange' } } ] } } };
+
+
 vows.describe('Tests for deferred values').addBatch({
   'Configuration file Tests': {
     'Using deferConfig() in a config file causes value to be evaluated at the end': function() {
@@ -39,6 +68,26 @@ vows.describe('Tests for deferred values').addBatch({
 
     "defer functions which return objects should still be treated as a single value." : function () {
       assert.deepEqual(CONFIG.get('map.centerPoint'), { lat: 3, lon: 4 });
+    },
+
+    "nested defer functions work": function() {
+      assert.equal(CONFIG.get('name.nickname'), 'Bob');
+    },
+
+    'service registry example': function() {
+      var svc = CONFIG.get('service.active');
+      assert.equal(svc.message, 'Real thing');
+      assert.equal(CONFIG.get('service.active.message'), 'Real thing');
+    },
+    
+    
+    "deferred stress test" : function() {
+      // Grab the subset of the result CONFIG that we're interested in
+      var subconfig = {};
+      Object.keys(expectedStress).forEach(function(key) {
+        subconfig[key] = CONFIG.get(key);
+      });
+      assert.deepEqual(expectedStress, subconfig);
     },
 
   }


### PR DESCRIPTION
Here is the improvement to the deferred resolver logic that we discussed on #266. 

@lorenwest, I completely understand your hesitancy about adding new code, as you described it, "to make it appear to be improved", but let me say a couple of things.

First, as I mentioned before, this feature has nothing whatsoever to do with promises, other than the (unfortunate) using the same terms. There is nothing async going on at all, and no "non-determinism". You asked earlier what would happen if someone read one of the config values before it was resolved, and I was confused at the time. But now I see that you were thinking that the config tree is exposed first and that the resolution happens asynchronously at some later time. In fact, the whole resolution process is synchronous, and very fast -- it's little more than a tree walk. No cloning or copying of trees, either -- the results of the "deferred" functions are grafted in place (just like they are now).

Second, this PR is an implementation, almost exactly, of what @markstos  described in [this comment](https://github.com/lorenwest/node-config/issues/266#issuecomment-207520735). One thing I didn't do was to add a boolean to record whether or not any deferreds are present. It's a good idea. I doubt it would be necessary for performance reasons, but if it is, it would be easy to add.

I put the new code into the defer.js module. I spent a long time painstakingly going over the algorithm, to make sure it is robust. I documented it in extensive comments in that module, and also in lib/resolver.md. The algorithm is a bit tricky, but it works really well. With this fix, you can basically write anything you want in terms of config variables that depend on other config variables -- in any order, using objects or arrays, and nested data structures, nested deferreds, etc. 

I wrote a lot of tests, and my working copy passes all the existing tests, but I'm not sure I covered everything. I didn't test it with the submodules feature. I tested a little bit with using class instances instead of plain-old-json objects as config data. There might be issues with deferreds that return those class instances -- but I don't know whether or not these are handled flawlessly with the existing scheme. If you point me to some test cases, I'd be happy to add more tests.