### PR TITLE
Fix prototype merge

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1416,11 +1416,10 @@ util.extendDeep = function(mergeInto) {
       }
 
       // Copy property descriptor otherwise, preserving accessors
-      else {
-        var descriptor = Object.getOwnPropertyDescriptor(Object(mergeFrom), prop);
-        if (descriptor) {
-          Object.defineProperty(mergeInto, prop, descriptor);
-        }
+      else if (Object.getOwnPropertyDescriptor(Object(mergeFrom), prop)){
+          Object.defineProperty(mergeInto, prop, Object.getOwnPropertyDescriptor(Object(mergeFrom), prop));
+      } else {
+          mergeInto[prop] = mergeFrom[prop];
       }
     }
   });

--- a/test/1-protected-test.js
+++ b/test/1-protected-test.js
@@ -168,6 +168,11 @@ vows.describe('Protected (hackable) utilities test')
       var extWith = {elem3:{sub2:"val6",sub3:"val7"}};
       CONFIG.util.extendDeep({}, orig, extWith);
       assert.deepEqual(orig, shouldBe);
+    },
+    'Keeps prototype methods intact': function() {
+      var orig = Object.create({has: function() {}});
+      var result = CONFIG.util.extendDeep({}, orig, {});
+      assert.isFunction(result.has);
     }
   },
 


### PR DESCRIPTION
In 1.20.1 extendDeep would some things including methods on the prototype (e.g. has).  With 1.20.2 that when __lookupGetter__ was removed.  The fix in 1.20.3 didn't fix that although it did guard against the cases when getPropertyDescriptor returned undefined.  This change restores the current code structure where if what is being copied isn't one of the known types (including property descriptor) then it is simply copied.  This change also creates a test for this case.  This test passes in 1.20.1, not in 1.20.2/3, and then again after change is applied.