### PR TITLE
util.loadFileConfigs: support optional source dir

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -625,7 +625,7 @@ util.getConfigSources = function() {
  * @method loadFileConfigs
  * @return config {Object} The configuration object
  */
-util.loadFileConfigs = function() {
+util.loadFileConfigs = function(configDir) {
 
   // Initialize
   var t = this,
@@ -633,7 +633,7 @@ util.loadFileConfigs = function() {
 
   // Initialize parameters from command line, environment, or default
   NODE_ENV = util.initParam('NODE_ENV', 'development');
-  CONFIG_DIR = util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
+  CONFIG_DIR = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
   if (CONFIG_DIR.indexOf('.') === 0) {
     CONFIG_DIR = Path.join(process.cwd() , CONFIG_DIR);
   }
@@ -701,41 +701,44 @@ util.loadFileConfigs = function() {
   });
 
   // Override configurations from the $NODE_CONFIG environment variable
-  var envConfig = {};
-  if (process.env.NODE_CONFIG) {
-    try {
-      envConfig = JSON.parse(process.env.NODE_CONFIG);
-    } catch(e) {
-      console.error('The $NODE_CONFIG environment variable is malformed JSON');
+  // NODE_CONFIG only applies to the base config
+  if (!configDir) {
+    var envConfig = {};
+    if (process.env.NODE_CONFIG) {
+      try {
+        envConfig = JSON.parse(process.env.NODE_CONFIG);
+      } catch(e) {
+        console.error('The $NODE_CONFIG environment variable is malformed JSON');
+      }
+      util.extendDeep(config, envConfig);
+      configSources.push({
+        name: "$NODE_CONFIG",
+        parsed: envConfig,
+      });
     }
-    util.extendDeep(config, envConfig);
-    configSources.push({
-      name: "$NODE_CONFIG",
-      parsed: envConfig,
-    });
-  }
 
-  // Override configurations from the --NODE_CONFIG command line
-  var cmdLineConfig = util.getCmdLineArg('NODE_CONFIG');
-  if (cmdLineConfig) {
-    try {
-      cmdLineConfig = JSON.parse(cmdLineConfig);
-    } catch(e) {
-      console.error('The --NODE_CONFIG={json} command line argument is malformed JSON');
+    // Override configurations from the --NODE_CONFIG command line
+    var cmdLineConfig = util.getCmdLineArg('NODE_CONFIG');
+    if (cmdLineConfig) {
+      try {
+        cmdLineConfig = JSON.parse(cmdLineConfig);
+      } catch(e) {
+        console.error('The --NODE_CONFIG={json} command line argument is malformed JSON');
+      }
+      util.extendDeep(config, cmdLineConfig);
+      configSources.push({
+        name: "--NODE_CONFIG argument",
+        parsed: cmdLineConfig,
+      });
     }
-    util.extendDeep(config, cmdLineConfig);
-    configSources.push({
-      name: "--NODE_CONFIG argument",
-      parsed: cmdLineConfig,
-    });
+
+    // Place the mixed NODE_CONFIG into the environment
+    env['NODE_CONFIG'] = JSON.stringify(util.extendDeep(envConfig, cmdLineConfig, {}));
   }
 
   // Override with environment variables if there is a custom-environment-variables.EXT mapping file
   var customEnvVars = util.getCustomEnvVars(CONFIG_DIR, extNames);
   util.extendDeep(config, customEnvVars);
-
-  // Place the mixed NODE_CONFIG into the environment
-  env['NODE_CONFIG'] = JSON.stringify(util.extendDeep(envConfig, cmdLineConfig, {}));
 
   // Extend the original config with the contents of runtime.json (backwards compatibility)
   var runtimeJson = util.parseFile(RUNTIME_JSON_FILENAME) || {};

--- a/test/5-config/default.js
+++ b/test/5-config/default.js
@@ -1,6 +1,7 @@
 
 var config = {
   siteName : 'default site name',
+  number : 5,
 };
 
 config.email = {

--- a/test/util.js
+++ b/test/util.js
@@ -4,8 +4,10 @@
 // Dependencies
 var vows = require('vows'),
     assert = require('assert'),
+    path = require('path'),
     config = require('../lib/config'),
-    initParam = config.util.initParam;
+    initParam = config.util.initParam,
+    loadFileConfigs = config.util.loadFileConfigs;
 
 vows.describe('Tests for config util functions')
 .addBatch({
@@ -34,6 +36,19 @@ vows.describe('Tests for config util functions')
         'Setting a zero value on the command line works. ': function () {
           process.argv=['ignore','ignore','--FROMARG=0'];
           assert.strictEqual(initParam('FROMARG','mydefault'),'0');
+        },
+    },
+    'Tests for util.loadFileConfigs': {
+        'It can load data from a given directory': function () {
+          var result = loadFileConfigs(path.join(__dirname, '5-config'));
+          assert.strictEqual(result.number, 5);
+        },
+        'It ignores NODE_CONFIG when loading from directory': function () {
+          var prev = process.env.NODE_CONFIG;
+          process.env.NODE_CONFIG = '{"number":4}'
+          var result = loadFileConfigs(path.join(__dirname, '5-config'));
+          assert.strictEqual(result.number, 5);
+          process.env.NODE_CONFIG = prev;
         },
     }
 })


### PR DESCRIPTION
Example use case: load module defaults which you then merge with util.setModuleDefaults
```jsx
import config from 'config'
const ourConfigDir = path.join(__dirname, 'config')
const baseConfig = config.util.loadFileConfigs(ourConfigDir)
config.util.setModuleDefaults('MyModule', baseConfig)
```

See #276 

