### PR TITLE
original/previous value for deferredConfig

### DIFF
--- a/defer.js
+++ b/defer.js
@@ -1,7 +1,7 @@
 // Create a deferredConfig prototype so that we can check for it when reviewing the configs later.
 function DeferredConfig () {
 }
-DeferredConfig.prototype.resolve = function (config) {};
+DeferredConfig.prototype.resolve = function (config, original) {};
 
 // Accept a function that we'll use to resolve this value later and return a 'deferred' configuration value to resolve it later.
 function deferConfig (func) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -777,7 +777,7 @@ util.resolveDeferredConfigs = function (config) {
         }
       } else {
         if (prop[property] instanceof DeferredConfig ) {
-          prop[property]= prop[property].resolve.call(completeConfig,completeConfig)
+          prop[property]= prop[property].resolve.call(completeConfig,completeConfig, prop[property]._original);
         }
         else {
           // Nothing to do. Keep the property how it is.
@@ -1419,8 +1419,14 @@ util.extendDeep = function(mergeInto) {
     // Cycle through each element of the object to merge from
     for (var prop in mergeFrom) {
 
-      // Extend recursively if both elements are objects and target is not really a deferred function
+      // save original value in deferred elements
+      var fromIsDeferredFunc = mergeFrom[prop] instanceof DeferredConfig;
       var isDeferredFunc = mergeInto[prop] instanceof DeferredConfig;
+
+      if (fromIsDeferredFunc && mergeInto.hasOwnProperty(prop)) {
+        mergeFrom[prop]._original = isDeferredFunc ? mergeInto[prop]._original : mergeInto[prop];
+      }
+      // Extend recursively if both elements are objects and target is not really a deferred function
       if (mergeFrom[prop] instanceof Date) {
         mergeInto[prop] = mergeFrom[prop];
       } else if (util.isObject(mergeInto[prop]) && util.isObject(mergeFrom[prop]) && !isDeferredFunc) {

--- a/test/3-config/default.js
+++ b/test/3-config/default.js
@@ -32,4 +32,14 @@ config.map = {
   }),
 };
 
+config.original = {
+  // An original value passed to deferred function
+  original: "an original value",
+
+  // A deferred function "skipped" by next deferred function
+  deferredOriginal: defer(function(cfg, original) {
+    return "this will not be used";
+  }),
+};
+
 module.exports = config;

--- a/test/3-config/local.js
+++ b/test/3-config/local.js
@@ -1,3 +1,4 @@
+var defer = require('../../defer').deferConfig;
 
 var config = {
  siteTitle : 'New Instance!',
@@ -5,6 +6,18 @@ var config = {
 
 config.map = {
   centerPoint :  { lat: 3, lon: 4 },
+};
+
+config.original = {
+  // An original value passed to deferred function
+  original: defer(function(cfg, original) {
+    return original;
+  }),
+
+  // This deferred function "skips" the previous one
+  deferredOriginal: defer(function(cfg, original) {
+    return original; // undefined
+  }),
 };
 
 module.exports = config;

--- a/test/3-deferred-configs.js
+++ b/test/3-deferred-configs.js
@@ -41,6 +41,13 @@ vows.describe('Tests for deferred values').addBatch({
       assert.deepEqual(CONFIG.get('map.centerPoint'), { lat: 3, lon: 4 });
     },
 
+    "defer function return original value." : function () {
+      assert.equal(CONFIG.original.original, 'an original value');
+    },
+
+    "second defer function return original value." : function () {
+      assert.equal(CONFIG.original.deferredOriginal, undefined);
+    },
   }
 })
 .export(module);


### PR DESCRIPTION
I would like to suggest this PR to extend functionality for deferredConfigs. This PR is fully backward compatible.

When merging a config file which has deferred values the value from the previous file is saved into the DeferredConfig object. Later when deferred values are resolved this saved value is passed to the resolver function.

I am currently developing a deferred resolver which allows me to load values from etcd – hopefully I will be able to release this in the next week. Yes, it is synchronously but this is ok in my context. When no value is in etcd I wanted to get the last one so I did this little change.

Maybe some other people are in need of this? :)

Here is an example:

```yaml
# default.yml
someValue: default
```

```js
// local.js
module.exports = {
  someValue: defer(function (cfg, original) {
    return getSomeFancyConfigOrUndefined() || original;
  }
}
```

When `getSomeFancyConfigORUndefined` is not able to get a value, we are able to use the `original` value now.