### PR TITLE
Play nice with transpilers by using variable requires (fixes #345)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -537,7 +537,7 @@ util.makeImmutable = function(object, property, value) {
   for (var i = 0; i < properties.length; i++) {
     var propertyName = properties[i],
         value = object[propertyName];
-    
+
     if (!(value instanceof RawConfig)) {
       Object.defineProperty(object, propertyName, {
         value: value,
@@ -872,7 +872,8 @@ util.parseFile = function(fullFilename) {
         //  Coffee = require("coffee-script");
         //}
 
-        Coffee = require("coffee-script");
+        var dep = "coffee-script"
+        Coffee = require(dep);
 
         // coffee-script >= 1.7.0 requires explicit registration for require() to work
         if (Coffee.register) {
@@ -883,7 +884,8 @@ util.parseFile = function(fullFilename) {
       configObject = require(fullFilename);
     }
     else if (extension === 'iced') {
-      Iced = require("iced-coffee-script");
+      var dep = "iced-coffee-script"
+      Iced = require(dep);
 
       // coffee-script >= 1.7.0 requires explicit registration for require() to work
       if (Iced.register) {
@@ -946,12 +948,14 @@ util.parseString = function (content, format) {
       // Lazy loading
       try {
         // Try to load the better js-yaml module
-        Yaml = require('js-yaml');
+        var dep = 'js-yaml'
+        Yaml = require(dep);
       }
       catch (e) {
         try {
           // If it doesn't exist, load the fallback visionmedia yaml module.
-          VisionmediaYaml = require('yaml');
+          var dep = 'yaml'
+          VisionmediaYaml = require(dep);
         }
         catch (e) { }
       }
@@ -982,7 +986,8 @@ util.parseString = function (content, format) {
       }
 
       if (!JSON5) {
-        JSON5 = require('json5');
+        var dep = 'json5'
+        JSON5 = require(dep);
       }
 
       configObject = JSON5.parse(content);
@@ -991,7 +996,8 @@ util.parseString = function (content, format) {
   else if (format === 'json5') {
 
     if (!JSON5) {
-      JSON5 = require('json5');
+      var dep = 'json5'
+      JSON5 = require(dep);
     }
 
     configObject = JSON5.parse(content);
@@ -999,7 +1005,8 @@ util.parseString = function (content, format) {
   } else if (format === 'hjson') {
 
     if (!HJSON) {
-      HJSON = require('hjson');
+      var dep = 'hjson'
+      HJSON = require(dep);
     }
 
     configObject = HJSON.parse(content);
@@ -1007,14 +1014,16 @@ util.parseString = function (content, format) {
   } else if (format === 'toml') {
 
     if(!TOML) {
-      TOML = require('toml');
+      var dep = 'toml'
+      TOML = require(dep);
     }
 
     configObject = TOML.parse(content);
   }
   else if (format === 'cson') {
     if (!CSON) {
-      CSON = require('cson');
+      var dep = 'cson'
+      CSON = require(dep);
     }
     // Allow comments in CSON files
     if (typeof CSON.parseSync === 'function') {
@@ -1025,13 +1034,15 @@ util.parseString = function (content, format) {
   }
   else if (format === 'properties') {
     if (!PPARSER) {
-      PPARSER = require('properties');
+      var dep = 'properties'
+      PPARSER = require(dep);
     }
     configObject = PPARSER.parse(content, { namespaces: true, variables: true, sections: true });
   } else if (format === 'xml') {
 
     if (!XML) {
-      XML = require('x2js');
+      var dep = 'x2js'
+      XML = require(dep);
     }
 
     var x2js = new XML();

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,6 +31,18 @@ var DEFAULT_CLONE_DEPTH = 20,
     configSources = [],          // Configuration sources - array of {name, original, parsed}
     checkMutability = true;      // Check for mutability/immutability on first get
 
+// Define soft dependencies so transpilers don't include everything
+var COFFEE_DEP = "coffee-script",
+    ICED_DEP = "iced-coffee-script",
+    JS_YAML_DEP = "js-yaml",
+    YAML_DEP = "yaml",
+    JSON5_DEP = "json5",
+    HJSON_DEP = "hjson",
+    TOML_DEP = "toml",
+    CSON_DEP = "cson",
+    PPARSER_DEP = "properties",
+    XML_DEP = "x2js";
+
 /**
  * <p>Application Configurations</p>
  *
@@ -872,8 +884,7 @@ util.parseFile = function(fullFilename) {
         //  Coffee = require("coffee-script");
         //}
 
-        var dep = "coffee-script"
-        Coffee = require(dep);
+        Coffee = require(COFFEE_DEP);
 
         // coffee-script >= 1.7.0 requires explicit registration for require() to work
         if (Coffee.register) {
@@ -884,8 +895,7 @@ util.parseFile = function(fullFilename) {
       configObject = require(fullFilename);
     }
     else if (extension === 'iced') {
-      var dep = "iced-coffee-script"
-      Iced = require(dep);
+      Iced = require(ICED_DEP);
 
       // coffee-script >= 1.7.0 requires explicit registration for require() to work
       if (Iced.register) {
@@ -948,14 +958,12 @@ util.parseString = function (content, format) {
       // Lazy loading
       try {
         // Try to load the better js-yaml module
-        var dep = 'js-yaml'
-        Yaml = require(dep);
+        Yaml = require(JS_YAML);
       }
       catch (e) {
         try {
           // If it doesn't exist, load the fallback visionmedia yaml module.
-          var dep = 'yaml'
-          VisionmediaYaml = require(dep);
+          VisionmediaYaml = require(YAML);
         }
         catch (e) { }
       }
@@ -986,8 +994,7 @@ util.parseString = function (content, format) {
       }
 
       if (!JSON5) {
-        var dep = 'json5'
-        JSON5 = require(dep);
+        JSON5 = require(JSON5_DEP);
       }
 
       configObject = JSON5.parse(content);
@@ -996,8 +1003,7 @@ util.parseString = function (content, format) {
   else if (format === 'json5') {
 
     if (!JSON5) {
-      var dep = 'json5'
-      JSON5 = require(dep);
+      JSON5 = require(JSON5_DEP);
     }
 
     configObject = JSON5.parse(content);
@@ -1005,8 +1011,7 @@ util.parseString = function (content, format) {
   } else if (format === 'hjson') {
 
     if (!HJSON) {
-      var dep = 'hjson'
-      HJSON = require(dep);
+      HJSON = require(HJSON_DEP);
     }
 
     configObject = HJSON.parse(content);
@@ -1014,16 +1019,14 @@ util.parseString = function (content, format) {
   } else if (format === 'toml') {
 
     if(!TOML) {
-      var dep = 'toml'
-      TOML = require(dep);
+      TOML = require(TOML_DEP);
     }
 
     configObject = TOML.parse(content);
   }
   else if (format === 'cson') {
     if (!CSON) {
-      var dep = 'cson'
-      CSON = require(dep);
+      CSON = require(CSON_DEP);
     }
     // Allow comments in CSON files
     if (typeof CSON.parseSync === 'function') {
@@ -1034,15 +1037,13 @@ util.parseString = function (content, format) {
   }
   else if (format === 'properties') {
     if (!PPARSER) {
-      var dep = 'properties'
-      PPARSER = require(dep);
+      PPARSER = require(PPARSER_DEP);
     }
     configObject = PPARSER.parse(content, { namespaces: true, variables: true, sections: true });
   } else if (format === 'xml') {
 
     if (!XML) {
-      var dep = 'x2js'
-      XML = require(dep);
+      XML = require(XML_DEP);
     }
 
     var x2js = new XML();


### PR DESCRIPTION
As discussed in #345 this PR moves all conditional requires in `lib/config.js` to use a variable module name. This allows transpilers like Webpack to properly resolve the dependency graph.