### PR TITLE
Support Electron environment

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -638,11 +638,20 @@ util.loadFileConfigs = function(configDir) {
   var t = this,
       config = {};
 
+  // Detect when running in the Electron environment
+  // https://github.com/lorenwest/node-config/issues/368
+  var workingDir;
+  if (process && process.versions && process.versions.electron) {
+    workingDir = require('electron').app.getAppPath();
+  } else {
+    workingDir = process.cwd();
+  }
+
   // Initialize parameters from command line, environment, or default
   NODE_ENV = util.initParam('NODE_ENV', 'development');
-  CONFIG_DIR = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
+  CONFIG_DIR = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( workingDir, 'config') );
   if (CONFIG_DIR.indexOf('.') === 0) {
-    CONFIG_DIR = Path.join(process.cwd() , CONFIG_DIR);
+    CONFIG_DIR = Path.join(workingDir , CONFIG_DIR);
   }
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
   HOST = util.initParam('HOST');


### PR DESCRIPTION
https://github.com/lorenwest/node-config/issues/368

Detect when running in an Electron environment. If running in Electron, retrieve the working directory from Electron instead of from the main process.