### PR TITLE
Add support for configuration files stored with git-crypt.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -29,7 +29,8 @@ var DEFAULT_CLONE_DEPTH = 20,
     privateUtil = {},
     deprecationWarnings = {},
     configSources = [],          // Configuration sources - array of {name, original, parsed}
-    checkMutability = true;      // Check for mutability/immutability on first get
+    checkMutability = true,      // Check for mutability/immutability on first get
+    gitCryptTestRegex = /^.GITCRYPT/; // regular expression to test for gitcrypt files.
 
 /**
  * <p>Application Configurations</p>
@@ -647,6 +648,7 @@ util.loadFileConfigs = function(configDir) {
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
   HOST = util.initParam('HOST');
   HOSTNAME = util.initParam('HOSTNAME');
+  CONFIG_SKIP_GITCRYPT = util.initParam('CONFIG_SKIP_GITCRYPT');
 
   // This is for backward compatibility
   RUNTIME_JSON_FILENAME = util.initParam('NODE_CONFIG_RUNTIME_JSON', Path.join(CONFIG_DIR , 'runtime.json') );
@@ -827,13 +829,14 @@ util.parseFile = function(fullFilename) {
   var t = this,
       extension = fullFilename.substr(fullFilename.lastIndexOf('.') + 1),
       configObject = null,
-      fileContent = null;
+      fileContent = null,
+      stat = null;
 
   // Return null if the file doesn't exist.
   // Note that all methods here are the Sync versions.  This is appropriate during
   // module loading (which is a synchronous operation), but not thereafter.
   try {
-    var stat = FileSystem.statSync(fullFilename);
+    stat = FileSystem.statSync(fullFilename);
     if (!stat || stat.size < 1) {
       return null;
     }
@@ -852,6 +855,15 @@ util.parseFile = function(fullFilename) {
 
   // Parse the file based on extension
   try {
+
+    // skip if it's a gitcrypt file and CONFIG_SKIP_GITCRYPT is true
+    if (CONFIG_SKIP_GITCRYPT) {
+      if (gitCryptTestRegex.test(fileContent)) {
+        console.error('WARNING: ' + fullFilename + ' is a git-crypt file and CONFIG_SKIP_GITCRYPT is set. skipping.');
+        return null;
+      }
+    }
+
     if (extension === 'js') {
       // Use the built-in parser for .js files
       configObject = require(fullFilename);
@@ -895,6 +907,9 @@ util.parseFile = function(fullFilename) {
     }
   }
   catch (e3) {
+    if (gitCryptTestRegex.test(fileContent)) {
+      console.error('ERROR: ' + fullFilename + ' is a git-crypt file and CONFIG_SKIP_GITCRYPT is not set.');
+    }
     throw new Error("Cannot parse config file: '" + fullFilename + "': " + e3);
   }
 


### PR DESCRIPTION
currently node-config crashes with a parse error if, for example, you have a production.json file encrypted with [git-crypt](https://github.com/AGWA/git-crypt) due to the file containing sensitive information. This is because such files are binary files.

This PR adds transparent support for git-crypt as follows:

* If none of your configuration files are encrypted with git-crypt, node-config behaviour is unchanged.
* If you *DO* have a configuration file encrypted with git-crypt:
    * If the ```CONFIG_SKIP_GITCRYPT``` environment variable is truthy, the file is ignored and a warning is emitted to the console.
    * If the ```CONFIG_SKIP_GITCRYPT``` environment variable is not set or is falsy, an additional error message is emitted to the console just prior to the (existing) parse error.

Of course, if you are using git-crypt but your git-crypt files are unlocked, node-config works perfectly already. This issue only applies to developers who do not have the files unlocked.