### PR TITLE
fix bug when user does export CONFIG_SKIP_GITCRYPT env

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -648,7 +648,7 @@ util.loadFileConfigs = function(configDir) {
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
   HOST = util.initParam('HOST');
   HOSTNAME = util.initParam('HOSTNAME');
-  CONFIG_SKIP_GITCRYPT = util.initParam('CONFIG_SKIP_GITCRYPT');
+  CONFIG_SKIP_GITCRYPT = util.initParam('CONFIG_SKIP_GITCRYPT', 1);
 
   // This is for backward compatibility
   RUNTIME_JSON_FILENAME = util.initParam('NODE_CONFIG_RUNTIME_JSON', Path.join(CONFIG_DIR , 'runtime.json') );

--- a/test/10-gitcrypt-test.js
+++ b/test/10-gitcrypt-test.js
@@ -41,21 +41,16 @@ vows.describe('Test git-crypt integration')
   },
 })
 .addBatch({
-  'initialization with encrypted files without CONFIG_SKIP_GITCRYPT': {
-    'An exception is thrown if CONFIG_SKIP_GITCRYPT is not set': function() {
+  'initialization with encrypted files with CONFIG_SKIP_GITCRYPT = 0': {
+    'An error log will be of "initialization with encrypted files without CONFIG_SKIP_GITCRYPT"': function() {
       // Hardcode $NODE_ENV=encrypted for testing
       process.env.NODE_ENV='encrypted';
 
       // Test Environment Variable Substitution
       process.env.CONFIG_SKIP_GITCRYPT = 0;
-      delete process.env["CONFIG_SKIP_GITCRYPT"];
 
-      assert.throws(
-        function () { 
-          CONFIG = requireUncached('../lib/config');
-        },
-        /Cannot parse config file/
-      );
+      CONFIG = requireUncached('../lib/config');
+      assert.equal(CONFIG.Customers.dbPassword, 'password will be overwritten.');
     }
   }
 })


### PR DESCRIPTION
Fix exception:

ReferenceError: CONFIG_SKIP_GITCRYPT is not defined
at util.loadFileConfigs (/usr/local/jive/servers/realtime/lib/node_modules/rt/lib/v2/services/connector/node_modules/config/lib/config.js:651:24)
at new Config (/usr/local/jive/servers/realtime/lib/node_modules/rt/lib/v2/services/connector/node_modules/config/lib/config.js:122:27)
at Object.<anonymous> (/usr/local/jive/servers/realtime/lib/node_modules/rt/lib/v2/services/connector/node_modules/config/lib/config.js:1735:31)

