### PR TITLE
Update config.js with correctly cased type def.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1633,8 +1633,8 @@ util.getCmdLineArg = function (searchFor) {
  * </p>
  *
  * @method getEnv
- * @param varName {STRING} The environment variable name
- * @return value {String} The value of the environment variable
+ * @param varName {String} The environment variable name
+ * @return {String} The value of the environment variable
  */
 util.getEnv = function (varName) {
   return env[varName];

--- a/lib/config.js
+++ b/lib/config.js
@@ -138,7 +138,7 @@ var util = Config.prototype.util = {};
  * @method getImpl
  * @param object {object} - Object to get the property for
  * @param property {string | array[string]} - The property name to get (as an array or '.' delimited string)
- * @return value {mixed} - Property value, including undefined if not defined.
+ * @return value {*} - Property value, including undefined if not defined.
  */
 var getImpl= function(object, property) {
   var t = this,
@@ -167,7 +167,7 @@ var getImpl= function(object, property) {
  *
  * @method get
  * @param property {string} - The configuration property to get. Can include '.' sub-properties.
- * @return value {mixed} - The property value
+ * @return value {*} - The property value
  */
 Config.prototype.get = function(property) {
   if(property === null || property === undefined){
@@ -456,7 +456,7 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
  * @method makeHidden
  * @param object {object} - The object to make a hidden property into.
  * @param property {string} - The name of the property to make hidden.
- * @param value {mixed} - (optional) Set the property value to this (otherwise leave alone)
+ * @param value {*} - (optional) Set the property value to this (otherwise leave alone)
  * @return object {object} - The original object is returned - for chaining.
  */
 util.makeHidden = function(object, property, value) {
@@ -509,7 +509,7 @@ util.makeHidden = function(object, property, value) {
  * @param object {object} - The object to specify immutable properties for
  * @param [property] {string | [string]} - The name of the property (or array of names) to make immutable.
  *        If not provided, all owned properties of the object are made immutable.
- * @param [value] {mixed | [mixed]} - Property value (or array of values) to set
+ * @param [value] {* | [*]} - Property value (or array of values) to set
  *        the property to before making immutable. Only used when setting a single
  *        property. Retained for backward compatibility.
  * @return object {object} - The original object is returned - for chaining.
@@ -1212,7 +1212,7 @@ util.cloneDeep = function cloneDeep(parent, depth, circular, prototype) {
  * @method setPath
  * @param object {object} - Object to set the property on
  * @param path {array[string]} - Array path to the property
- * @param value {mixed} - value to set, ignoring null
+ * @param value {*} - value to set, ignoring null
  */
 util.setPath = function (object, path, value) {
   var nextKey = null;
@@ -1566,7 +1566,7 @@ util.stripComments = function(fileStr, stringRegex) {
  *
  * @protected
  * @method isObject
- * @param arg {MIXED} An argument of any type.
+ * @param arg {*} An argument of any type.
  * @return {boolean} TRUE if the arg is an object, FALSE if not
  */
 util.isObject = function(obj) {
@@ -1609,7 +1609,7 @@ util.initParam = function (paramName, defaultValue) {
  *
  * @method getCmdLineArg
  * @param searchFor {String} The argument name to search for
- * @return {Mixed} false if the argument was not found, the argument value if found
+ * @return {*} false if the argument was not found, the argument value if found
  */
 util.getCmdLineArg = function (searchFor) {
     var cmdLineArgs = process.argv.slice(2, process.argv.length),

--- a/lib/config.js
+++ b/lib/config.js
@@ -1608,8 +1608,8 @@ util.initParam = function (paramName, defaultValue) {
  * </p>
  *
  * @method getCmdLineArg
- * @param searchFor {STRING} The argument name to search for
- * @return {MIXED} FALSE if the argument was not found, the argument value if found
+ * @param searchFor {String} The argument name to search for
+ * @return {Mixed} false if the argument was not found, the argument value if found
  */
 util.getCmdLineArg = function (searchFor) {
     var cmdLineArgs = process.argv.slice(2, process.argv.length),


### PR DESCRIPTION
Some IDEs and other tools incorrectly state that argument of type `String` is not assignable to param of type `STRING`. This fixes those sort of issues.