### PR TITLE
Flag for no custom env

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -538,7 +538,7 @@ util.makeImmutable = function(object, property, value) {
   for (var i = 0; i < properties.length; i++) {
     var propertyName = properties[i],
         value = object[propertyName];
-    
+
     if (!(value instanceof RawConfig)) {
       Object.defineProperty(object, propertyName, {
         value: value,
@@ -746,8 +746,10 @@ util.loadFileConfigs = function(configDir) {
   }
 
   // Override with environment variables if there is a custom-environment-variables.EXT mapping file
-  var customEnvVars = util.getCustomEnvVars(CONFIG_DIR, extNames);
-  util.extendDeep(config, customEnvVars);
+  if (process.env.NO_CUSTOM_ENV !== 'true') {
+    var customEnvVars = util.getCustomEnvVars(CONFIG_DIR, extNames);
+    util.extendDeep(config, customEnvVars);
+  }
 
   // Extend the original config with the contents of runtime.json (backwards compatibility)
   var runtimeJson = util.parseFile(RUNTIME_JSON_FILENAME) || {};

--- a/test/11-config/custom-environment-variables.json
+++ b/test/11-config/custom-environment-variables.json
@@ -1,0 +1,8 @@
+{
+  // With a comment
+  "customEnvironmentVariables": {
+    "mappedBy": {
+      "json": "CUSTOM_JSON_ENVIRONMENT_VAR"
+    }
+  }
+}

--- a/test/11-config/default.json
+++ b/test/11-config/default.json
@@ -1,0 +1,20 @@
+{
+  "Customers": {
+    "dbName":"from_default_json",
+    "dbPassword":"password will be overwritten.",
+    "dbPassword2":"password will be overwritten.",
+    "lang":["en","es"]
+  },
+  "AnotherModule": {
+    "parm1":"value1"
+  },
+  "staticArray": [2,1,3],
+  "Inline": {"a": "", "b": "1"},
+  "ContainsQuote": "\"this has a quote\"",
+  "MoreComplexQuote": "<a href=\"http://localhost:3000/offers/reply?id={{system.contact.value}}\">Test String</a>",
+  "customEnvironmentVariables": {
+    "mappedBy": {
+      "json": "DEFAULT_JSON_VAR"
+    }
+  }
+}

--- a/test/11-no-custom-env-config-test.js
+++ b/test/11-no-custom-env-config-test.js
@@ -1,0 +1,91 @@
+
+// Dependencies
+var vows = require('vows'),
+    assert = require('assert'),
+    FileSystem = require('fs');
+
+/**
+ * <p>Unit tests for the node-config library.  To run type:</p>
+ * <pre>npm test</pre>
+ * <p>Or, in a project that uses node-config:</p>
+ * <pre>npm test config</pre>
+ *
+ * @class ConfigTest
+ */
+
+var CONFIG, override;
+vows.describe('Test NO_CUSTOM_ENV')
+.addBatch({
+  'Library initialization': {
+    topic : function () {
+      // Change the configuration directory for testing
+      process.env.NODE_CONFIG_DIR = __dirname + '/11-config';
+
+      // Hardcode $NODE_ENV=test for testing
+      // process.env.NODE_ENV='test';
+
+      // Test for multi-instance applications
+      // process.env.NODE_APP_INSTANCE='3';
+
+      // Test $NODE_CONFIG environment and --NODE_CONFIG command line parameter
+      process.env.NODE_CONFIG='{"EnvOverride":{"parm3":"overridden from $NODE_CONFIG","parm4":100}}';
+      process.argv.push('--NODE_CONFIG={"EnvOverride":{"parm5":"overridden from --NODE_CONFIG","parm6":101}}');
+
+      // Test Environment Variable Substitution
+      override = 'CUSTOM VALUE FROM JSON ENV MAPPING';
+      process.env.CUSTOM_JSON_ENVIRONMENT_VAR = override;
+
+      process.env.NO_CUSTOM_ENV='true'
+
+      CONFIG = requireUncached('../lib/config');
+
+      return CONFIG;
+
+    },
+    'Config library is available': function() {
+      assert.isObject(CONFIG);
+    },
+    'Config extensions are included with the library': function() {
+      assert.isFunction(CONFIG.util.cloneDeep);
+    }
+  },
+})
+.addBatch({
+  'Configurations from the $NODE_CONFIG environment variable': {
+    'Configuration can come from the $NODE_CONFIG environment': function() {
+      assert.equal(CONFIG.EnvOverride.parm3, 'overridden from $NODE_CONFIG');
+    },
+
+    'Type correct configurations from $NODE_CONFIG': function() {
+      assert.equal(CONFIG.EnvOverride.parm4, 100);
+    }
+
+  },
+
+  'Configurations from the --NODE_CONFIG command line': {
+    'Configuration can come from the --NODE_CONFIG command line argument': function() {
+      assert.equal(CONFIG.EnvOverride.parm5, 'overridden from --NODE_CONFIG');
+    },
+
+    'Type correct configurations from --NODE_CONFIG': function() {
+      assert.equal(CONFIG.EnvOverride.parm6, 101);
+    }
+
+  },
+
+  'Configurations from custom environment variables': {
+    'Configuration can NOT come from an environment variable mapped in custom_environment_variables.json': function () {
+      assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.json'), 'DEFAULT_JSON_VAR');
+    }
+  },
+})
+.export(module);
+
+//
+// Because require'ing config creates and caches a global singleton,
+// We have to invalidate the cache to build new object based on the environment variables above
+function requireUncached(module){
+   delete require.cache[require.resolve(module)];
+   return require(module);
+}
+

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -31,6 +31,8 @@ vows.describe('Test suite for node-config')
       process.env.NODE_CONFIG='{"EnvOverride":{"parm3":"overridden from $NODE_CONFIG","parm4":100}}';
       process.argv.push('--NODE_CONFIG={"EnvOverride":{"parm5":"overridden from --NODE_CONFIG","parm6":101}}');
 
+      process.env.NO_CUSTOM_ENV=''
+
       // Test Environment Variable Substitution
       override = 'CUSTOM VALUE FROM JSON ENV MAPPING';
       process.env.CUSTOM_JSON_ENVIRONMENT_VAR = override;


### PR DESCRIPTION
I would like to be able to ensure that ENV vars do not override my test config when running tests in CI.I could not see how that would currently be possible (in a simple way). Would something like this be an acceptable option?

(needs some cleanup too but I'm out of time right now..)
..and it should probably stop NODE_CONFIG too