### PR TITLE
Allow consumers of Config.prototype.get to specify a default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .project
 node_modules
 npm-debug.log
+.idea

--- a/lib/config.js
+++ b/lib/config.js
@@ -167,18 +167,24 @@ var getImpl= function(object, property) {
  *
  * @method get
  * @param property {string} - The configuration property to get. Can include '.' sub-properties.
+ * @param [defaultValue] {*} - Return this value if the property doesn't exist.
  * @return value {*} - The property value
  */
-Config.prototype.get = function(property) {
+Config.prototype.get = function(property, defaultValue) {
   if(property === null || property === undefined){
     throw new Error("Calling config.get with null or undefined argument");
   }
   var t = this,
       value = getImpl(t, property);
 
-  // Produce an exception if the property doesn't exist
   if (value === undefined) {
-    throw new Error('Configuration property "' + property + '" is not defined');
+    // Produce an exception if the property doesn't exist and the consumer didn't specify a default
+    if(!defaultValue) {
+      throw new Error('Configuration property "' + property + '" is not defined');
+    }
+
+    // continue to work with the given defaultValue
+    value = defaultValue;
   }
 
   // Make configurations immutable after first get (unless disabled)


### PR DESCRIPTION
Currently, if I call `Config.prototype.get('var')`, and `var` cannot be resolved, the module throws an error. This is cool, but I'd like to be able to optionally specify a defaultValue as the second positional argument to avoid the exception or `Config.prototype.has()` roundtrip in my application.

I'd like to provide tests, but I don't understand the structure of the tests directory. What is the meaning of all the '3-config', '4-config', '5-config' ,..., directories? Could someone please point me to the right location? :-)