### PR TITLE
If environment variable exist use it

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -173,8 +173,13 @@ Config.prototype.get = function(property) {
   if(property === null || property === undefined){
     throw new Error("Calling config.get with null or undefined argument");
   }
-  var t = this,
+
+  if(typeof env[property] !== "undefined") {
+    var value = env[property];
+  } else {
+    var t = this,
       value = getImpl(t, property);
+  }
 
   // Produce an exception if the property doesn't exist
   if (value === undefined) {


### PR DESCRIPTION
In response of my issue #395 

Allow using environment variable in get if exist.

I don't know if you had this discussion about this features before.