### PR TITLE
Resolve #366 - Add TypeScript support

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -687,7 +687,7 @@ util.loadFileConfigs = function(configDir) {
 
   baseNames.push('local', 'local-' + NODE_ENV);
 
-  var extNames = ['js', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
+  var extNames = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
   baseNames.forEach(function(baseName) {
     extNames.forEach(function(extName) {
 
@@ -867,6 +867,18 @@ util.parseFile = function(fullFilename) {
     if (extension === 'js') {
       // Use the built-in parser for .js files
       configObject = require(fullFilename);
+    } 
+    else if (extension === 'ts') {
+      require('ts-node').register({
+        lazy: true,
+        compilerOptions: {
+          allowJs: true,
+        }
+      });
+
+      // Because of ES6 modules usage, `default` is treated as named export (like any other)
+      // Therefore config is a value of `default` key.
+      configObject = require(fullFilename).default;
     }
     else if (extension === 'coffee') {
       // .coffee files can be loaded with either coffee-script or iced-coffee-script.

--- a/package.json
+++ b/package.json
@@ -19,15 +19,20 @@
   },
   "license": "MIT",
   "dependencies": {
-    "json5": "0.4.0"
+    "json5": "0.4.0",
+    "os-homedir": "1.0.2"
   },
   "devDependencies": {
+    "@types/node": "^7.0.8",
     "coffee-script": ">=1.7.0",
     "cson": "^3.0.1",
     "hjson": "^1.2.0",
     "js-yaml": "^3.2.2",
     "properties": "~1.2.1",
+    "semver": "5.3.0",
     "toml": "^2.0.6",
+    "ts-node": "^2.1.0",
+    "typescript": "^2.2.1",
     "underscore": "^1.8.3",
     "vows": ">=0.8.1",
     "x2js": "^2.0.1"

--- a/test/1-protected-test.js
+++ b/test/1-protected-test.js
@@ -4,6 +4,8 @@
  * @module test
  */
 
+var requireUncached = require('./_utils/requireUncached');
+
 var vows = require('vows');
 var assert = require('assert');
 
@@ -45,7 +47,7 @@ vows.describe('Protected (hackable) utilities test')
       process.env['CUSTOM_JSON_ENVIRONMENT_VAR'] = override;
 
       // Dependencies
-      CONFIG = requireUncached('../lib/config');
+      CONFIG = requireUncached(__dirname + '/../lib/config');
 
       return CONFIG;
 
@@ -631,12 +633,3 @@ vows.describe('Protected (hackable) utilities test')
 
 })
 .export(module);
-
-
-//
-// Because require'ing config creates and caches a global singleton,
-// We have to invalidate the cache to build new object based on the environment variables above
-function requireUncached(module){
-   delete require.cache[require.resolve(module)];
-   return require(module);
-}

--- a/test/10-gitcrypt-test.js
+++ b/test/10-gitcrypt-test.js
@@ -1,3 +1,4 @@
+var requireUncached = require('./_utils/requireUncached');
 
 // Dependencies
 var vows = require('vows'),
@@ -27,7 +28,7 @@ vows.describe('Test git-crypt integration')
       delete process.env["NODE_CONFIG"]
       delete process.env["CUSTOM_JSON_ENVIRONMENT_VAR"];
 
-      CONFIG = requireUncached('../lib/config');
+      CONFIG = requireUncached(__dirname + '/../lib/config');
 
       return CONFIG;
 
@@ -52,7 +53,7 @@ vows.describe('Test git-crypt integration')
 
       assert.throws(
         function () { 
-          CONFIG = requireUncached('../lib/config');
+          CONFIG = requireUncached(__dirname + '/../lib/config');
         },
         /Cannot parse config file/
       );
@@ -60,12 +61,3 @@ vows.describe('Test git-crypt integration')
   }
 })
 .export(module);
-
-//
-// Because require'ing config creates and caches a global singleton,
-// We have to invalidate the cache to build new object based on the environment variables above
-function requireUncached(module){
-   delete require.cache[require.resolve(module)];
-   return require(module);
-}
-

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -1,3 +1,4 @@
+var requireUncached = require('./_utils/requireUncached');
 
 // Dependencies
 var vows = require('vows'),
@@ -35,7 +36,7 @@ vows.describe('Test suite for node-config')
       override = 'CUSTOM VALUE FROM JSON ENV MAPPING';
       process.env.CUSTOM_JSON_ENVIRONMENT_VAR = override;
 
-      CONFIG = requireUncached('../lib/config');
+      CONFIG = requireUncached(__dirname + '/../lib/config');
 
       return CONFIG;
 
@@ -352,12 +353,3 @@ vows.describe('Test suite for node-config')
   },
 })
 .export(module);
-
-//
-// Because require'ing config creates and caches a global singleton,
-// We have to invalidate the cache to build new object based on the environment variables above
-function requireUncached(module){
-   delete require.cache[require.resolve(module)];
-   return require(module);
-}
-

--- a/test/4-array-merging.js
+++ b/test/4-array-merging.js
@@ -1,3 +1,4 @@
+var requireUncached = require('./_utils/requireUncached');
 
 // Test declaring deferred values.
 // The key config files involved here are:
@@ -16,7 +17,7 @@ process.env.NODE_APP_INSTANCE='array-merge';
 
 // Because require'ing config creates and caches a global singleton,
 // We have to invalidate the cache to build new object based on the environment variables above
-var CONFIG = requireUncached('../lib/config');
+var CONFIG = requireUncached(__dirname + '/../lib/config');
 
 // Dependencies
 var vows = require('vows'),
@@ -43,9 +44,3 @@ vows.describe('Tests for merging arrays').addBatch({
   }
 })
 .export(module);
-
-
-function requireUncached(module){
-   delete require.cache[require.resolve(module)];
-   return require(module);
-}

--- a/test/5-getConfigSources.js
+++ b/test/5-getConfigSources.js
@@ -1,4 +1,4 @@
-
+var requireUncached = require('./_utils/requireUncached');
 
 // Dependencies
 var vows   = require('vows'),
@@ -16,7 +16,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
       delete process.env.NODE_APP_INSTANCE;
       process.env.NODE_CONFIG_STRICT_MODE=0;
       process.argv = ["node","path/to/some.js","--NODE_CONFIG='{}'"];
-      var config = requireUncached('../lib/config');
+      var config = requireUncached(__dirname + '/../lib/config');
       return config.util.getConfigSources();
     },
 
@@ -41,7 +41,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
       delete process.env.NODE_APP_INSTANCE;
       process.env.NODE_CONFIG_STRICT_MODE=0;
       process.argv = [];
-      var config = requireUncached('../lib/config');
+      var config = requireUncached(__dirname + '/../lib/config');
       return config.util.getConfigSources();
     },
 
@@ -65,7 +65,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
       delete process.env.NODE_CONFIG;
       delete process.env.NODE_APP_INSTANCE;
       process.argv = [];
-      var config = requireUncached('../lib/config');
+      var config = requireUncached(__dirname + '/../lib/config');
       return config.util.getConfigSources();
     },
 
@@ -88,7 +88,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
       delete process.env.NODE_CONFIG;
       delete process.env.NODE_APP_INSTANCE;
       process.argv = [];
-      var config = requireUncached('../lib/config');
+      var config = requireUncached(__dirname + '/../lib/config');
       return config.util.getConfigSources();
     },
 
@@ -103,11 +103,3 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
  }
 })
 .export(module);
-
-//
-// Because require'ing config creates and caches a global singleton,
-// We have to invalidate the cache to build new object based on the environment variables above
-function requireUncached(module){
-   delete require.cache[require.resolve(module)];
-   return require(module);
-}

--- a/test/6-strict-mode.js
+++ b/test/6-strict-mode.js
@@ -1,3 +1,5 @@
+var requireUncached = require('./_utils/requireUncached');
+
 // Dependencies
 var vows = require('vows'),
     assert = require('assert');
@@ -55,7 +57,7 @@ function _expectException (opts) {
       process.env.NODE_ENV                = opts.NODE_ENV;
       delete process.env.NODE_CONFIG;
       try { 
-        var config = requireUncached('../lib/config');
+        var config = requireUncached(__dirname + '/../lib/config');
       }
       catch (e) {
         return e;
@@ -82,13 +84,4 @@ function _expectException (opts) {
       }
     }
   };
-}
-
-
-//
-// Because require'ing config creates and caches a global singleton,
-// We have to invalidate the cache to build new object based on the environment variables above
-function requireUncached(module){
-   delete require.cache[require.resolve(module)];
-   return require(module);
 }

--- a/test/7-unicode-situations.js
+++ b/test/7-unicode-situations.js
@@ -1,3 +1,4 @@
+var requireUncached = require('./_utils/requireUncached');
 
 // Dependencies
 var vows = require('vows'),
@@ -15,7 +16,7 @@ delete process.env.NODE_APP_INSTANCE;
 
 process.env.NODE_CONFIG_STRICT_MODE = false;
 
-var CONFIG = requireUncached('../lib/config');
+var CONFIG = requireUncached(__dirname + '/../lib/config');
 
 
 vows.describe('Tests for Unicode situations')
@@ -44,12 +45,3 @@ vows.describe('Tests for Unicode situations')
     }
 })
 .export(module);
-
-//
-// Because require'ing config creates and caches a global singleton,
-// We have to invalidate the cache to build new object based on the environment variables above
-function requireUncached(module) {
-    delete require.cache[require.resolve(module)];
-    return require(module);
-}
-

--- a/test/8-config-extending.js
+++ b/test/8-config-extending.js
@@ -1,3 +1,4 @@
+var requireUncached = require('./_utils/requireUncached');
 
 // Dependencies
 var vows = require('vows'),
@@ -15,7 +16,7 @@ delete process.env.NODE_APP_INSTANCE;
 
 process.env.NODE_CONFIG_STRICT_MODE = false;
 
-var CONFIG = requireUncached('../lib/config');
+var CONFIG = requireUncached(__dirname + '/../lib/config');
 
 
 vows.describe('Tests for config extending')
@@ -35,12 +36,3 @@ vows.describe('Tests for config extending')
     }
 })
 .export(module);
-
-//
-// Because require'ing config creates and caches a global singleton,
-// We have to invalidate the cache to build new object based on the environment variables above
-function requireUncached(module) {
-    delete require.cache[require.resolve(module)];
-    return require(module);
-}
-

--- a/test/9-raw-configs.js
+++ b/test/9-raw-configs.js
@@ -1,10 +1,12 @@
+var requireUncached = require('./_utils/requireUncached');
+
 'use strict';
 
 process.env.NODE_CONFIG_DIR = __dirname + '/9-config';
 process.env.NODE_ENV='test';
 process.env.NODE_APP_INSTANCE='raw';
 
-var CONFIG = requireUncached('../lib/config');
+var CONFIG = requireUncached(__dirname + '/../lib/config');
 
 // Dependencies
 var vows = require('vows'),
@@ -20,9 +22,3 @@ vows.describe('Tests for raw config values').addBatch({
   }
 })
 .export(module);
-
-
-function requireUncached(module){
-   delete require.cache[require.resolve(module)];
-   return require(module);
-}

--- a/test/_utils/isSupportedVersion.js
+++ b/test/_utils/isSupportedVersion.js
@@ -1,0 +1,5 @@
+var semver = require('semver');
+
+module.exports = function (version) {
+    return !semver.lt(process.versions.node, version);
+}

--- a/test/_utils/requireUncached.js
+++ b/test/_utils/requireUncached.js
@@ -1,0 +1,7 @@
+//
+// Because require'ing config creates and caches a global singleton,
+// We have to invalidate the cache to build new object based on the environment variables above
+module.exports = function requireUncached(module){
+   delete require.cache[require.resolve(module)];
+   return require(module);
+}

--- a/test/x-config-test-ts.js
+++ b/test/x-config-test-ts.js
@@ -1,0 +1,59 @@
+var requireUncached = require('./_utils/requireUncached');
+var isSupportedVersion = require('./_utils/isSupportedVersion');
+
+if(!isSupportedVersion('4.0.0'))  {
+    return false;
+}
+
+// Dependencies
+var vows = require('vows'),
+    assert = require('assert'),
+    FileSystem = require('fs');
+
+/**
+ * <p>Unit tests for the node-config library.  To run type:</p>
+ * <pre>npm test</pre>
+ * <p>Or, in a project that uses node-config:</p>
+ * <pre>npm test config</pre>
+ *
+ * @class ConfigTest
+ */
+
+var CONFIG, override;
+vows.describe('Test suite for node-config TypeScript support')
+.addBatch({
+  'Library initialization with TypeScript config files': {
+    topic : function () {
+      
+      // Clear after previous tests
+      process.env.NODE_APP_INSTANCE = '';
+      process.env.NODE_ENV = '';
+      process.env.NODE_CONFIG = '';
+      
+      // Change the configuration directory for testing
+      process.env.NODE_CONFIG_DIR = __dirname + '/x-config-ts';
+
+      // Disable after previous tests
+      process.env.NODE_CONFIG_STRICT_MODE = false;
+
+      CONFIG = requireUncached(__dirname + '/../lib/config');
+
+      return CONFIG;
+
+    },
+    'Config library is available': function() {
+      assert.isObject(CONFIG);
+    }
+  },
+})
+.addBatch({
+  'Configuration file Tests': {
+    'Loading configurations from a TypeScript file is correct': function() {
+      assert.equal(CONFIG.siteTitle, 'New Instance!');
+    }
+  },
+})
+.export(module);
+
+
+

--- a/test/x-config-ts/default.ts
+++ b/test/x-config-ts/default.ts
@@ -1,0 +1,40 @@
+import { Config } from './types';
+import { deferConfig as defer } from '../../defer.js';
+
+const defaultConfig: Config = {
+  siteTitle : 'Site title',
+  latitude  : 1,
+  longitude : 2
+};
+
+// Set up a default value which refers to another value.
+// The resolution of the value is deferred until all the config files have been loaded
+// So that if 'config.siteTitle' is overridden, this will point to the correct value.
+defaultConfig['welcomeEmail'] = {
+  subject :  defer(cfg => `Welcome to ${cfg.siteTitle}`),
+  // A plain function should be not disturbed.
+  aFunc() {
+    return "Still just a function.";
+  },
+
+  // Look ma, no arg passing. The main config object is bound to 'this'
+  justThis: defer(function () {
+    return `Welcome to this ${this.siteTitle}`;
+  }),
+};
+
+defaultConfig['map'] = {
+  centerPoint : defer(function () {
+    return { lat: this.latitude, lon: this.longitude };
+  }),
+};
+
+defaultConfig['original'] = {
+  // An original value passed to deferred function
+  original: "an original value",
+
+  // A deferred function "skipped" by next deferred function
+  deferredOriginal: defer((cfg, original) => "this will not be used"),
+};
+
+export default defaultConfig;

--- a/test/x-config-ts/local.ts
+++ b/test/x-config-ts/local.ts
@@ -1,0 +1,20 @@
+import { Config } from './types';
+import { deferConfig as defer } from '../../defer';
+
+const localConfig: Config = {
+ siteTitle : 'New Instance!',
+};
+
+localConfig['map'] = {
+  centerPoint :  { lat: 3, lon: 4 },
+};
+
+localConfig['original'] = {
+  // An original value passed to deferred function
+  original: defer((cfg, original) => original),
+
+  // This deferred function "skips" the previous one
+  deferredOriginal: defer((cfg, original) => original),
+};
+
+export default localConfig;

--- a/test/x-config-ts/types.ts
+++ b/test/x-config-ts/types.ts
@@ -1,0 +1,8 @@
+export interface Config {
+  siteTitle?: string;
+  latitude?: number;
+  longitude?: number;
+  welcomeEmail?: object;
+  map?: object;
+  original?: object;
+};

--- a/test/x-deferred-configs-ts.js
+++ b/test/x-deferred-configs-ts.js
@@ -1,9 +1,14 @@
 var requireUncached = require('./_utils/requireUncached');
+var isSupportedVersion = require('./_utils/isSupportedVersion');
+
+if(!isSupportedVersion('4.0.0'))  {
+    return false;
+}
 
 // Test declaring deferred values.
 
 // Change the configuration directory for testing
-process.env.NODE_CONFIG_DIR = __dirname + '/3-config';
+process.env.NODE_CONFIG_DIR = __dirname + '/x-config-ts';
 
 // Hardcode $NODE_ENV=test for testing
 process.env.NODE_ENV='test';
@@ -19,7 +24,7 @@ var CONFIG = requireUncached(__dirname + '/../lib/config');
 var vows = require('vows'),
     assert = require('assert');
 
-vows.describe('Tests for deferred values - JavaScript').addBatch({
+vows.describe('Tests for deferred values - TypeScript').addBatch({
   'Configuration file Tests': {
     'Using deferConfig() in a config file causes value to be evaluated at the end': function() {
         // The deferred function was declared in default-defer.js


### PR DESCRIPTION
This branch is adding TypeScript support by adding `*.ts` extensions handling with `ts-node` programmatic API.

Deferred config test is prefixed with `x-*` because when running multiple tests in parallel, `ts-node` is trying to parse multiple files with same name, putting them to same directory without prefixing etc. With `x/y/z` prefixing we are sure that this test will run as last and we won't see such error messages:

> Unable to compile TypeScript
> Cannot write file '/Library/WebServer/Documents/node-config/$$ts-node$$/test/config/default.js' because it would be overwritten by multiple input files.

Lazy loading of `ts-node` module is enabled by default and `allowJs` is set to true because we need to be able to require `defer.js` in example.