### PR TITLE
Add .raw method

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -155,6 +155,9 @@ var getImpl= function(object, property) {
   return getImpl(value, elems.slice(1));
 };
 
+Config.prototype.raw = function() {
+  return JSON.parse(JSON.stringify(this)))
+}
 
 /**
  * <p>Get a configuration value</p>


### PR DESCRIPTION
Fix #223 

I normally need to acces to the raw `config` file, this is the trick that I do:

```js
const config = JSON.parse(JSON.stringify(require('config')))
```

I simply put into the codebase for do that transparently.

Out of the box works, but not sure if inside of the core it will work, but I want to init this PR 😄 