### PR TITLE
update supported nodejs platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 before_install:
   - npm update -g npm
 node_js:
+  - "8.0"
+  - "7.0"
   - "6.0"
   - "4.4"
-  - "0.12"
-  - "0.10"
-  - "0.8"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "http://github.com/lorenwest/node-config.git"
   },
   "engines": {
-    "node": ">0.4.x"
+    "node": ">= 4.0.0"
   },
   "scripts": {
     "test": "./node_modules/vows/bin/vows test/*.js --spec"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "properties": "~1.2.1",
     "semver": "5.3.0",
     "toml": "^2.0.6",
-    "ts-node": "^2.1.0",
-    "typescript": "^2.2.1",
+    "ts-node": "^3.3.0",
+    "typescript": "^2.4.2",
     "underscore": "^1.8.3",
     "vows": ">=0.8.1",
     "x2js": "^2.0.1"


### PR DESCRIPTION
As per https://github.com/lorenwest/node-config/pull/428#issuecomment-321730793, this PR will remove non-supported nodejs versions (0.8, 0.10, 0.12); and add support for v7, v8 for travisci.