### PR TITLE
add nodejs9 to travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 before_install:
   - npm update -g npm
 node_js:
+  - "9"
   - "8"
   - "7"
   - "6"


### PR DESCRIPTION
This MR will enable travis ci to run the node-config test cases on the nodejs 9 runtime which was released Nov 1.

I've run the test cases locally using node v9.1.0 locally; all 206 cases passed successfully.