### PR TITLE
Add failing native promise test

### DIFF
--- a/test/3-config/default.js
+++ b/test/3-config/default.js
@@ -5,7 +5,7 @@ var config = {
   siteTitle : 'Site title',
   latitude  : 1,
   longitude : 2,
-
+  nativePromise: Promise.resolve('A native promise value')
 };
 
 // Set up a default value which refers to another value.

--- a/test/3-deferred-configs.js
+++ b/test/3-deferred-configs.js
@@ -49,6 +49,12 @@ vows.describe('Tests for deferred values - JavaScript').addBatch({
     "second defer function return original value." : function () {
       assert.equal(CONFIG.original.deferredOriginal, undefined);
     },
+
+    "native promise can be subscribed to" : function () {
+      return CONFIG.nativePromise.then(val => {
+        assert.equal(val, 'A native promise value')
+      })
+    }
   }
 })
 .export(module);


### PR DESCRIPTION
Node has had native promise support for a long time. However, defining a native promise in your config results in a value that cannot be successfully subscribed to. I suspect some sort of weird binding is occurring somewhere inside of config, which causes the `this` of the promise to be incorrect. 