### PR TITLE
Fixed 'hostname' value selection when there is no environment variable for that

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -664,9 +664,6 @@ util.loadFileConfigs = function(configDir) {
   try {
     var hostName = HOST || HOSTNAME;
 
-    // Store the hostname that won.
-    env.HOSTNAME = hostName;
-
     if (!hostName) {
         var OS = require('os');
         hostName = OS.hostname();
@@ -674,6 +671,9 @@ util.loadFileConfigs = function(configDir) {
   } catch (e) {
     hostName = '';
   }
+
+  // Store the hostname that won.
+  env.HOSTNAME = hostName;
 
   // Read each file in turn
   var baseNames = ['default', NODE_ENV];

--- a/test/13-node_env-hostname.js
+++ b/test/13-node_env-hostname.js
@@ -1,0 +1,54 @@
+var requireUncached = require('./_utils/requireUncached');
+
+'use strict';
+
+var NODE_CONFIG_DIR = __dirname + '/12-config'
+
+// Dependencies
+var vows = require('vows'),
+    assert = require('assert');
+
+vows.describe('Tests for HOSTNAME and HOST environment variables')
+.addBatch({
+    'When there is no HOSTNAME neither HOST env': {
+      topic: function() {
+        // Test HOST and HOSTNAME
+        delete process.env.HOST;
+        delete process.env.HOSTNAME;
+
+        return requireUncached(__dirname + '/../lib/config');
+      },
+      'OS.hostname() is the winner': function(CONFIG) {
+        assert.equal(typeof CONFIG.util.getEnv('HOSTNAME'), 'string');
+      }
+    }
+})
+.addBatch({
+  'When HOSTNAME env is setted': {
+    topic: function() {
+      // Test HOST and HOSTNAME
+      delete process.env.HOST;
+      process.env.HOSTNAME = 'some.machine';
+
+      return requireUncached(__dirname + '/../lib/config');
+    },
+    'HOSTNAME env variable is the winner': function(CONFIG) {
+      assert.equal(CONFIG.util.getEnv('HOSTNAME'), 'some.machine');
+    }
+  }
+})
+.addBatch({
+  'When HOST env is setted': {
+    topic: function() {
+      // Test HOST and HOSTNAME
+      delete process.env.HOSTNAME;
+      process.env.HOST = 'other.machine';
+
+      return requireUncached(__dirname + '/../lib/config');
+    },
+    'HOST env variable is the winner': function(CONFIG) {
+      assert.equal(CONFIG.util.getEnv('HOSTNAME'), 'other.machine');
+    }
+  }
+})
+.export(module);


### PR DESCRIPTION
Hi,

We are facing some issues in some distros that do not have HOSTNAME (or HOST) environment variable setted. In this case, we are receiving `undefined` result when trying to `config.util.getEnv('HOSTNAME')`.

This PR is a suggestion to try to do what says in the comments (lib/config.js:662)

> Determine the host name from the OS module, $HOST, or $HOSTNAME