### PR TITLE
Fixes #437 (ts-node double registration)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -875,12 +875,14 @@ util.parseFile = function(fullFilename) {
       configObject = require(fullFilename);
     }
     else if (extension === 'ts') {
-      require('ts-node').register({
-        lazy: true,
-        compilerOptions: {
-          allowJs: true,
-        }
-      });
+      if (!require.extensions['ts']) {
+        require('ts-node').register({
+          lazy: true,
+          compilerOptions: {
+            allowJs: true,
+          }
+        });
+      }
 
       // Because of ES6 modules usage, `default` is treated as named export (like any other)
       // Therefore config is a value of `default` key.


### PR DESCRIPTION
Fixes #437.
node-config should not register ts-node in case there is already .ts extension handler.
  