### PR TITLE
allows both coffeescript v1 and v2 to parse .coffee config files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -34,6 +34,7 @@ var DEFAULT_CLONE_DEPTH = 20,
 
 // Define soft dependencies so transpilers don't include everything
 var COFFEE_DEP = "coffee-script",
+COFFEE2_DEP = "coffeescript",
 ICED_DEP = "iced-coffee-script",
 JS_YAML_DEP = "js-yaml",
 YAML_DEP = "yaml",
@@ -917,7 +918,15 @@ util.parseFile = function(fullFilename) {
         //  Coffee = require("coffee-script");
         //}
 
-        Coffee = require(COFFEE_DEP);
+        try {
+          Coffee = require(COFFEE_DEP);
+        } catch (err) {
+          try {
+            Coffee = require(COFFEE2_DEP);
+          } catch (err) {
+            console.error('ERROR: coffee-script (v1) or coffeescript (v2) is required to parse config files with extension ".coffee".');
+          }
+        }
 
         // coffee-script >= 1.7.0 requires explicit registration for require() to work
         if (Coffee.register) {


### PR DESCRIPTION
Coffeescript version 2 has its dash removed from the module name. This PR allows both `coffee-script` and `coffeescript` as module name.