### PR TITLE
Support for nested raw() in javascript configurations

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -186,13 +186,6 @@ Config.prototype.get = function(property) {
   if(property === null || property === undefined){
     throw new Error("Calling config.get with null or undefined argument");
   }
-  var t = this,
-      value = getImpl(t, property);
-
-  // Produce an exception if the property doesn't exist
-  if (value === undefined) {
-    throw new Error('Configuration property "' + property + '" is not defined');
-  }
 
   // Make configurations immutable after first get (unless disabled)
   if (checkMutability) {
@@ -201,9 +194,12 @@ Config.prototype.get = function(property) {
     }
     checkMutability = false;
   }
+  var t = this,
+      value = getImpl(t, property);
 
-  if (value instanceof RawConfig) {
-    value = value.resolve();
+  // Produce an exception if the property doesn't exist
+  if (value === undefined) {
+    throw new Error('Configuration property "' + property + '" is not defined');
   }
 
   // Return the value
@@ -552,7 +548,13 @@ util.makeImmutable = function(object, property, value) {
     var propertyName = properties[i],
         value = object[propertyName];
 
-    if (!(value instanceof RawConfig)) {
+    if (value instanceof RawConfig) {
+      Object.defineProperty(object, propertyName, {
+        value: value.resolve(),
+        writable: false,
+        configurable: false
+      });
+    } else {
       Object.defineProperty(object, propertyName, {
         value: value,
         writable : false,

--- a/test/9-config/default.js
+++ b/test/9-config/default.js
@@ -5,5 +5,13 @@ module.exports = {
   testObj: raw({ foo: 'bar' }),
   yell: raw(function(input) {
     return input + '!';
+  }),
+  innerRaw: {
+    innerCircularReference: raw(process.stdout)
+  },
+  nestedRaw: raw({
+    nested: {
+      test: process.stdout
+    }
   })
 }

--- a/test/9-raw-configs.js
+++ b/test/9-raw-configs.js
@@ -15,9 +15,18 @@ var vows = require('vows'),
 vows.describe('Tests for raw config values').addBatch({
   'Configuration file Tests': {
     'Objects wrapped with raw should be unmodified': function() {
-        assert.equal(CONFIG.get('circularReference'), process.stdout);
-        assert.deepEqual(CONFIG.get('testObj'), { foo: 'bar' })
-        assert.isFunction(CONFIG.get('yell'));
+      assert.equal(CONFIG.get('circularReference'), process.stdout);
+      assert.deepEqual(CONFIG.get('testObj'), { foo: 'bar' })
+      assert.isFunction(CONFIG.get('yell'));
+    },
+    'Inner configuration objects wrapped with raw should be unmodified': function() {
+      assert.equal(CONFIG.get('innerRaw').innerCircularReference, process.stdout);
+      assert.equal(CONFIG.get('innerRaw.innerCircularReference'), process.stdout);
+    },
+    'Supports multiple levels of nesting': function() {
+      assert.equal(CONFIG.get('nestedRaw').nested.test, process.stdout);
+      assert.equal(CONFIG.get('nestedRaw.nested').test, process.stdout);
+      assert.equal(CONFIG.get('nestedRaw.nested.test'), process.stdout);
     }
   }
 })


### PR DESCRIPTION
Moving the `raw` wrapped object unwrapping into `makeImmutable`
is piggy-backing on the existing recursive object graph traversal
to ensure that regardless of how deep a raw-wrapped object is
within the configuration, it will be unwrapped.

The ordering of `makeImmutable` and `getImpl` was flipped in order
to consistently return an immutable config. Previously, a mutable
configuration was returned on first `get()`, and an immutable one
on subsequent `get()`s.

Fixes lorenwest/node-config#467