### PR TITLE
remove unused dependency, bump up json5, avoid shipping extra file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 node_modules
 test
 tools
+ISSUE_TEMPLATE.md
 .*

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "json5": "0.4.0",
-    "os-homedir": "1.0.2"
+    "json5": "^1.0.1"
   },
   "devDependencies": {
     "@types/node": "^7.0.8",


### PR DESCRIPTION
Title says all.
`json5@1` ships significantly less files as they added a `.npmignore` themselves.
`os-homedir` is simply unused and just bloat.
`ISSUE_TEMPLATE.md` is not relevant for consumers.