### PR TITLE
Immutable arrays

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -555,6 +555,10 @@ util.makeImmutable = function(object, property, value) {
         writable: false,
         configurable: false
       });
+    } else if (Array.isArray(value)) {
+      Object.defineProperty(object, propertyName, {
+        value: Object.freeze(value)
+      });
     } else {
       Object.defineProperty(object, propertyName, {
         value: value,

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -214,6 +214,25 @@ vows.describe('Test suite for node-config')
     }
   },
 
+  'Assuring a configuration array property can be made immutable': {
+    'Correctly unable to change an immutable configuration': function() {
+      CONFIG.util.makeImmutable(CONFIG.TestModule, 'arr1');
+      CONFIG.TestModule.arr1 = ['bad value'];
+      assert.isTrue(CONFIG.TestModule.arr1[0] == 'arrValue1');
+    },
+
+    'Correctly unable to add values to immutable array': function() {
+      CONFIG.util.makeImmutable(CONFIG.TestModule, 'arr1');
+      try {
+        CONFIG.TestModule.arr1.push('bad value');
+      } catch (err) {
+        assert.isTrue(err.name == 'TypeError');
+      }
+
+      assert.isTrue(!CONFIG.TestModule.arr1.includes('bad value'));
+    }
+  },
+
   'get() tests': {
     'The function exists': function() {
       assert.isFunction(CONFIG.get);

--- a/test/config/default.js
+++ b/test/config/default.js
@@ -1,7 +1,8 @@
 // Common configuration parameters
 module.exports = {
   TestModule: {
-    parm1:"value1"
+    parm1:"value1",
+    arr1: ["arrValue1"]
   },
   Customers: {
     dbHost:'base',


### PR DESCRIPTION
When immutable is called upon a config, this change freezes any arrays found. If there is an attempt to push a value onto the array, a TypeError is thrown.

I'm not sure if this is a desired approach for this library, as most attempted modifications to immutable keys are silently ignored by default. Throwing an error seems a bit harsh... Open to suggestions.