### PR TITLE
Ensure config array items and objects are sealed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .project
 node_modules
 npm-debug.log
+.idea

--- a/lib/config.js
+++ b/lib/config.js
@@ -422,6 +422,9 @@ util.makeImmutable = function(object, property, value) {
         configurable: false
       });
     } else if (Array.isArray(value)) {
+      // Ensure object items of this array are also immutable.
+      value.forEach((item, index) => { if (util.isObject(item) || Array.isArray(item)) util.makeImmutable(item) })
+
       Object.defineProperty(object, propertyName, {
         value: Object.freeze(value)
       });
@@ -431,6 +434,9 @@ util.makeImmutable = function(object, property, value) {
         writable : false,
         configurable: false
       });
+
+      // Ensure new properties can not be added.
+      Object.preventExtensions(object)
 
       // Call recursively if an object.
       if (util.isObject(value)) {

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -14,7 +14,7 @@ var vows = require('vows'),
  * @class ConfigTest
  */
 
-var CONFIG, override;
+var CONFIG, MODULE_CONFIG, override;
 vows.describe('Test suite for node-config')
 .addBatch({
   'Library initialization': {
@@ -326,9 +326,10 @@ vows.describe('Test suite for node-config')
 
   'Configuration for module developers': {
     topic: function() {
+      MODULE_CONFIG = requireUncached(__dirname + '/../lib/config');
 
       // Set some parameters for the test module
-      return CONFIG.util.setModuleDefaults("TestModule", {
+      return MODULE_CONFIG.util.setModuleDefaults("TestModule", {
         parm1: 1000, parm2: 2000, parm3: 3000,
         nested: {
           param4: 4000,
@@ -338,12 +339,12 @@ vows.describe('Test suite for node-config')
     },
 
     'The setModuleDefaults() method is available': function() {
-      assert.isFunction(CONFIG.util.setModuleDefaults);
+      assert.isFunction(MODULE_CONFIG.util.setModuleDefaults);
     },
 
     'The module config is in the CONFIG object': function(moduleConfig) {
-      assert.isObject(CONFIG.TestModule);
-      assert.deepEqual(CONFIG.TestModule, moduleConfig);
+      assert.isObject(MODULE_CONFIG.TestModule);
+      assert.deepEqual(MODULE_CONFIG.TestModule, moduleConfig);
     },
 
     'Local configurations are mixed in': function(moduleConfig) {
@@ -370,11 +371,11 @@ vows.describe('Test suite for node-config')
         }
       };
 
-      CONFIG.util.setModuleDefaults('BKTestModule', BKTestModuleDefaults);
-      CONFIG.util.setModuleDefaults('services.OtherTestModule', OtherTestModuleDefaults);
+      MODULE_CONFIG.util.setModuleDefaults('BKTestModule', BKTestModuleDefaults);
+      MODULE_CONFIG.util.setModuleDefaults('services.OtherTestModule', OtherTestModuleDefaults);
 
-      var testModuleConfig = CONFIG.get('BKTestModule');
-      var testSubModuleConfig = CONFIG.get('services');
+      var testModuleConfig = MODULE_CONFIG.get('BKTestModule');
+      var testSubModuleConfig = MODULE_CONFIG.get('services');
 
       assert.deepEqual(BKTestModuleDefaults.nested, testModuleConfig.get('nested'));
       assert.deepEqual(OtherTestModuleDefaults.other, testSubModuleConfig.OtherTestModule.other);


### PR DESCRIPTION
Merge request for:
https://github.com/lorenwest/node-config/issues/505

These changes ensure config properties of type array and their child objects are made immutable recursively, and prevent adding new properties to objects.

The following test is broken:
"Prototypes are applied by setModuleDefaults even if no previous config exists for the module"
due to the fact that setModuleDefaults will update the config object with default values, which in some use cases will add new properties.

I think this conflicts with the config object being immutable, but not sure how setModuleDefaults should behave -> should this method create non immutable copies of config values, merge them with defaults and then make them immutable (if ALLOW_CONFIG_MUTATIONS === false)?

@markstos  @lorenwest 