### PR TITLE
Feature : Add default value to get method

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -181,11 +181,19 @@ var getImpl= function(object, property) {
  *
  * @method get
  * @param property {string} - The configuration property to get. Can include '.' sub-properties.
+ * @param defaultValue {string} - The default value if configuration property not set.
  * @return value {*} - The property value
  */
-Config.prototype.get = function(property) {
-  if(property === null || property === undefined){
-    throw new Error("Calling config.get with null or undefined argument");
+Config.prototype.get = function(property,defaultValue = null) {
+
+  if((property === null || property === undefined) && defaultValue === null){
+    throw new Error("Calling config.get with null or undefined arguments");
+  }
+
+  if((property === null || property === undefined) && defaultValue !== null){
+
+    return defaultValue ; 
+
   }
 
   // Make configurations immutable after first get (unless disabled)
@@ -199,12 +207,14 @@ Config.prototype.get = function(property) {
       value = getImpl(t, property);
 
   // Produce an exception if the property doesn't exist
-  if (value === undefined) {
+  if (value === undefined && defaultValue === null) {
     throw new Error('Configuration property "' + property + '" is not defined');
   }
 
+
+
   // Return the value
-  return value;
+  return value || defaultValue;
 };
 
 /**


### PR DESCRIPTION
Now you can set the default value of a property 


````
var config = require('config');
// with localhost here as default value of  Customer.dbConfig.Host if is null or undefined
var dbConfig = config.get('Customer.dbConfig.Host', 'localhost');

````