### PR TITLE
Don't extend the input module config with its own key

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -283,7 +283,6 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   util.setPath(t, moduleName.split('.'), getImpl(t, moduleName) || {});
 
   // Extend local configurations into the module config
-  util.setPath(moduleConfig, moduleName.split('.'), getImpl(moduleConfig, moduleName) || {});
   util.extendDeep(moduleConfig, getImpl(t, moduleName));
 
   // Merge the extended configs without replacing the original

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -347,6 +347,12 @@ vows.describe('Test suite for node-config')
       assert.deepEqual(MODULE_CONFIG.TestModule, moduleConfig);
     },
 
+    // Regression test for https://github.com/lorenwest/node-config/issues/518
+    'The module config did not extend itself with its own name': function(moduleConfig) {
+      assert.isFalse('TestModule' in moduleConfig);
+      assert.isFalse('TestModule' in MODULE_CONFIG.TestModule);
+    },
+
     'Local configurations are mixed in': function(moduleConfig) {
       assert.equal(moduleConfig.parm1, "value1");
     },


### PR DESCRIPTION
* Remove unnecessary line causing the bug.
* Added a new regression test for this.
* Existing tests still pass.

Fix for #518.