### PR TITLE
replace var keyword with const in the example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ $ vi config/default.json
 **Use configs in your code:**
 
 ```js
-var config = require('config');
+const config = require('config');
 //...
-var dbConfig = config.get('Customer.dbConfig');
+const dbConfig = config.get('Customer.dbConfig');
 db.connect(dbConfig, ...);
 
 if (config.has('optionalFeature.detail')) {
-  var detail = config.get('optionalFeature.detail');
+  const detail = config.get('optionalFeature.detail');
   //...
 }
 ```


### PR DESCRIPTION
 const is implemented in node >= 6.0.0 so it is safe to replace the var keyword.