### PR TITLE
Add async configuration support - asyncConfig

### DIFF
--- a/async.js
+++ b/async.js
@@ -1,0 +1,59 @@
+var deferConfig = require('./defer').deferConfig;
+
+function AsyncConfig () {}
+AsyncConfig.prototype.getPromise = function () { return Promise.resolve(); };
+
+/**
+ * @param promiseOrFunc   the promise will determine a property's value once resolved
+ *                        can also be a function to defer which resolves to a promise
+ * @returns {AsyncConfig}   a 'async' configuration value to resolve later with `resolveAsyncConfigs`
+ */
+function asyncConfig (promiseOrFunc) {
+  if (typeof promiseOrFunc === 'function') {  // also acts as deferConfig
+    return deferConfig(function (config, original) {
+      return asyncConfig(promiseOrFunc.call(config, config, original));
+    });
+  }
+  var obj = Object.create(AsyncConfig.prototype);
+  obj.getPromise = function() { return promiseOrFunc; };
+  return obj;
+}
+
+/**
+ * Do not use `config.get` before executing this method, it will freeze the config object
+ * @param config    the main config object, returned from require('config')
+ * @returns {Promise<config>}   once all promises are resolved, return the original config object
+ */
+function resolveAsyncConfigs(config) {
+  var promises = [];
+  (function iterate(prop) {
+    var propsToSort = [];
+    for (var property in prop) {
+      if (prop.hasOwnProperty(property) && prop[property] != null) {
+        propsToSort.push(property);
+      }
+    }
+    propsToSort.sort().forEach(function(property) {
+      if (prop[property].constructor === Object) {
+        iterate(prop[property]);
+      }
+      else if (prop[property].constructor === Array) {
+        prop[property].forEach(iterate);
+      }
+      else if (prop[property] instanceof AsyncConfig) {
+        promises.push(
+          prop[property].getPromise().then(function(val) { prop[property] = val; }, function(err) {
+            prop[property] = undefined;
+            console.error(err);
+          })
+        );
+      }
+    });
+  })(config);
+  return Promise.all(promises).then(function() { return config; });
+}
+
+module.exports.asyncConfig = asyncConfig;
+module.exports.AsyncConfig = AsyncConfig;
+
+module.exports.resolveAsyncConfigs = resolveAsyncConfigs;

--- a/test/15-async-configs.js
+++ b/test/15-async-configs.js
@@ -1,0 +1,62 @@
+var resolveAsyncConfigs = require('../async').resolveAsyncConfigs;
+var requireUncached = require('./_utils/requireUncached');
+
+// Test declaring deferred values.
+
+// Change the configuration directory for testing
+process.env.NODE_CONFIG_DIR = __dirname + '/15-config';
+
+// Hardcode $NODE_ENV=test for testing
+process.env.NODE_ENV='test';
+
+// Test for multi-instance applications
+process.env.NODE_APP_INSTANCE='async';
+
+// Because require'ing config creates and caches a global singleton,
+// We have to invalidate the cache to build new object based on the environment variables above
+var CONFIG = requireUncached(__dirname + '/../lib/config');
+
+// Dependencies
+var vows = require('vows'),
+    assert = require('assert');
+
+vows.describe('Tests for async values - JavaScript').addBatch({
+  'Configuration file Tests': {
+    topic: function() {
+      resolveAsyncConfigs(CONFIG).then(function(config) {
+        this.callback(null, config);
+      }.bind(this)).catch(function(err) {
+        this.callback(err);
+      }.bind(this));
+    },
+
+    'Using asyncConfig() in a config file causes value to be evaluated by resolveAsyncConfigs': function() {
+      // The deferred function was declared in default-defer.js
+      // Then local-defer.js is located which overloads the siteTitle mentioned in the function
+      // Finally the deferred configurations, now referencing the 'local' siteTitle
+      assert.equal(CONFIG.welcomeEmail.subject, 'Welcome to New Instance!');
+    },
+
+    'values which are functions remain untouched unless they are instance of AsyncConfig': function() {
+      // If this had been treated as a deferred config value it would blow-up.
+      assert.equal(CONFIG.welcomeEmail.aFunc(), 'Still just a function.');
+    },
+
+    // This defer function didn't use args, but relied 'this' being bound to the main config object
+    "async functions can simply refer to 'this'" : function () {
+      assert.equal(CONFIG.welcomeEmail.justThis, 'Welcome to this New Instance!');
+    },
+
+    "async promises which return objects should still be treated as a single value." : function () {
+      assert.deepEqual(CONFIG.get('map.centerPoint'), { lat: 3, lon: 4 });
+    },
+
+    "async promise return original value." : function () {
+      assert.equal(CONFIG.original.original, 'an original value');
+    },
+
+    "second async promise return local value." : function () {
+      assert.equal(CONFIG.original.originalPromise, 'not an original value');
+    },
+  }
+}).export(module);

--- a/test/15-async-configs.js
+++ b/test/15-async-configs.js
@@ -1,7 +1,13 @@
-var resolveAsyncConfigs = require('../async').resolveAsyncConfigs;
 var requireUncached = require('./_utils/requireUncached');
+var isSupportedVersion = require('./_utils/isSupportedVersion');
 
-// Test declaring deferred values.
+if(!isSupportedVersion('7.6.0'))  {
+  return false;
+}
+
+var resolveAsyncConfigs = require('../async').resolveAsyncConfigs;
+
+// Test declaring async values.
 
 // Change the configuration directory for testing
 process.env.NODE_CONFIG_DIR = __dirname + '/15-config';
@@ -31,18 +37,15 @@ vows.describe('Tests for async values - JavaScript').addBatch({
     },
 
     'Using asyncConfig() in a config file causes value to be evaluated by resolveAsyncConfigs': function() {
-      // The deferred function was declared in default-defer.js
-      // Then local-defer.js is located which overloads the siteTitle mentioned in the function
-      // Finally the deferred configurations, now referencing the 'local' siteTitle
       assert.equal(CONFIG.welcomeEmail.subject, 'Welcome to New Instance!');
     },
 
     'values which are functions remain untouched unless they are instance of AsyncConfig': function() {
-      // If this had been treated as a deferred config value it would blow-up.
+      // If this had been treated as a async config value it would blow-up.
       assert.equal(CONFIG.welcomeEmail.aFunc(), 'Still just a function.');
     },
 
-    // This defer function didn't use args, but relied 'this' being bound to the main config object
+    // This async function didn't use args, but relied 'this' being bound to the main config object
     "async functions can simply refer to 'this'" : function () {
       assert.equal(CONFIG.welcomeEmail.justThis, 'Welcome to this New Instance!');
     },

--- a/test/15-config/default.js
+++ b/test/15-config/default.js
@@ -1,0 +1,44 @@
+
+var asyncConfig = require('../../async').asyncConfig;
+
+var config = {
+  siteTitle : 'Site title',
+  latitude  : 1,
+  longitude : 2,
+};
+
+// Set up a default value which refers to another value.
+// The resolution of the value is deferred until all the config files have been loaded
+// So that if 'config.siteTitle' is overridden, this will point to the correct value.
+config.welcomeEmail = {
+  subject :  asyncConfig(async function (cfg) {
+    var siteTitle = await Promise.resolve(cfg.siteTitle);
+    return "Welcome to "+siteTitle;
+  }),
+  promiseSubject: asyncConfig(Promise.resolve("Welcome to Promise response")),
+  // A plain function should be not disturbed.
+  aFunc  : function () {
+    return "Still just a function.";
+  },
+  // Look ma, no arg passing. The main config object is bound to 'this'
+  justThis: asyncConfig(async function () {
+    var siteTitle = await Promise.resolve(this.siteTitle);
+    return "Welcome to this "+siteTitle;
+  }),
+};
+
+config.map = {
+  centerPoint : asyncConfig(async function () {
+    var latitude = await Promise.resolve(this.latitude);
+    return { lat: latitude, lon: this.longitude };
+  }),
+};
+
+config.original = {
+  // An original value passed to deferred function
+  original: "an original value",
+  // An original value passed to deferred function
+  originalPromise: asyncConfig(Promise.resolve("this will not be used")),
+};
+
+module.exports = config;

--- a/test/15-config/local.js
+++ b/test/15-config/local.js
@@ -1,0 +1,20 @@
+var asyncConfig = require('../../async').asyncConfig;
+
+var config = {
+ siteTitle : 'New Instance!',
+};
+
+config.map = {
+  centerPoint :  { lat: 3, lon: 4 },
+};
+
+config.original = {
+  // An original value passed to deferred function
+  original: asyncConfig(async function(cfg, original) {
+    return await Promise.resolve(original);
+  }),
+  // An original value passed to deferred function
+  originalPromise: asyncConfig(Promise.resolve("not an original value")),
+};
+
+module.exports = config;


### PR DESCRIPTION
I took the liberty to extend my former solution and added support for both promises and async functions.
If we only allow promises and a user will want to override one promise with another, then although the value will be correct the code for both promises would execute, which isn't optimal.
By allowing `asyncConfig` to receive an async function (a function which return a promise) we solve this problem with the same logic used for the `deferConfig`. 
So now if we detect a function we wrap it with `asyncConfig` and pass it to `deferConfig` to handle its initialization. `deferConfig` will execute the function which will return an `AsyncConfig` instance containing the resulted promise, later to be handled by `resolveAsyncConfigs`.

Issue: https://github.com/lorenwest/node-config/issues/186
Wiki draft: https://github.com/lorenwest/node-config/wiki/Asynchronous-Configurations

The draft might require additional work..