### PR TITLE
Fixed #449 - support native promises by default, no need to wrap them in raw

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1392,7 +1392,7 @@ util.extendDeep = function(mergeInto) {
       }
 
       // Copy recursively if the mergeFrom element is an object (or array or fn)
-      else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object') {
+      else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object' && !util.isPromise(mergeFrom[prop])) {
         mergeInto[prop] = util.cloneDeep(mergeFrom[prop], depth -1);
       }
 
@@ -1499,11 +1499,23 @@ util.stripComments = function(fileStr, stringRegex) {
  *
  * @protected
  * @method isObject
- * @param arg {*} An argument of any type.
+ * @param obj {*} An argument of any type.
  * @return {boolean} TRUE if the arg is an object, FALSE if not
  */
 util.isObject = function(obj) {
   return (obj !== null) && (typeof obj === 'object') && !(Array.isArray(obj));
+};
+
+/**
+ * Is the specified argument a javascript promise?
+ *
+ * @protected
+ * @method isPromise
+ * @param obj {*} An argument of any type.
+ * @returns {boolean}
+ */
+util.isPromise = function(obj) {
+  return util.isObject(obj) && obj.toString() === '[object Promise]';
 };
 
 /**

--- a/test/9-config/default.js
+++ b/test/9-config/default.js
@@ -6,6 +6,7 @@ module.exports = {
   yell: raw(function(input) {
     return input + '!';
   }),
+  aPromise: Promise.resolve('this is a promise result'),
   innerRaw: {
     innerCircularReference: raw(process.stdout)
   },

--- a/test/9-raw-configs.js
+++ b/test/9-raw-configs.js
@@ -14,9 +14,13 @@ var vows = require('vows'),
 
 vows.describe('Tests for raw config values').addBatch({
   'Configuration file Tests': {
+    topic: function() {
+      try { CONFIG.get('aPromise').then(val => this.callback(null, val)); }
+      catch(err) { this.callback(); }
+    },
     'Objects wrapped with raw should be unmodified': function() {
       assert.equal(CONFIG.get('circularReference'), process.stdout);
-      assert.deepEqual(CONFIG.get('testObj'), { foo: 'bar' })
+      assert.deepEqual(CONFIG.get('testObj'), { foo: 'bar' });
       assert.isFunction(CONFIG.get('yell'));
     },
     'Inner configuration objects wrapped with raw should be unmodified': function() {
@@ -27,6 +31,9 @@ vows.describe('Tests for raw config values').addBatch({
       assert.equal(CONFIG.get('nestedRaw').nested.test, process.stdout);
       assert.equal(CONFIG.get('nestedRaw.nested').test, process.stdout);
       assert.equal(CONFIG.get('nestedRaw.nested.test'), process.stdout);
+    },
+    'Supports keeping promises raw by default': function(err, val) {
+      assert.equal(val, 'this is a promise result');
     }
   }
 })


### PR DESCRIPTION
Very little changes in code, validate a promise using `util.isObject(obj) && obj.toString() === '[object Promise]'`.

What do you think?