### PR TITLE
#181 - Support custom Parsers definitions from an external source

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -4,19 +4,10 @@
 // http://lorenwest.github.com/node-config
 
 // Dependencies
-var Yaml = null,    // External libraries are lazy-loaded
-    VisionmediaYaml = null,  // only if these file types exist.
-    Coffee = null,
-    Iced = null,
-    CSON = null,
-    PPARSER = null,
-    JSON5 = null,
-    TOML = null,
-    HJSON = null,
-    XML = null,
-    deferConfig = require('../defer').deferConfig,
+var deferConfig = require('../defer').deferConfig,
     DeferredConfig = require('../defer').DeferredConfig,
     RawConfig = require('../raw').RawConfig,
+    Parser = require('../parser'),
     Utils = require('util'),
     Path = require('path'),
     FileSystem = require('fs');
@@ -31,20 +22,6 @@ var DEFAULT_CLONE_DEPTH = 20,
     configSources = [],          // Configuration sources - array of {name, original, parsed}
     checkMutability = true,      // Check for mutability/immutability on first get
     gitCryptTestRegex = /^.GITCRYPT/; // regular expression to test for gitcrypt files.
-
-// Define soft dependencies so transpilers don't include everything
-var COFFEE_2_DEP = "coffeescript",
-COFFEE_DEP = "coffee-script",
-ICED_DEP = "iced-coffee-script",
-JS_YAML_DEP = "js-yaml",
-YAML_DEP = "yaml",
-JSON5_DEP = "json5",
-HJSON_DEP = "hjson",
-TOML_DEP = "toml",
-CSON_DEP = "cson",
-PPARSER_DEP = "properties",
-XML_DEP = "x2js",
-TS_DEP = "ts-node";
 
 /**
  * <p>Application Configurations</p>
@@ -153,7 +130,7 @@ var util = Config.prototype.util = {};
  * @private
  * @method getImpl
  * @param object {object} - Object to get the property for
- * @param property {string | array[string]} - The property name to get (as an array or '.' delimited string)
+ * @param property {string|string[]} - The property name to get (as an array or '.' delimited string)
  * @return value {*} - Property value, including undefined if not defined.
  */
 var getImpl= function(object, property) {
@@ -170,7 +147,6 @@ var getImpl= function(object, property) {
   }
   return getImpl(value, elems.slice(1));
 };
-
 
 /**
  * <p>Get a configuration value</p>
@@ -594,7 +570,7 @@ util.loadFileConfigs = function(configDir) {
   });
 
 
-  var extNames = util.parsers.autoloadOrder;
+  var extNames = Parser.getOrder();
   baseNames.forEach(function(baseName) {
     extNames.forEach(function(extName) {
 
@@ -731,10 +707,7 @@ util.resolveDeferredConfigs = function (config) {
  * @return {configObject} The configuration object parsed from the file
  */
 util.parseFile = function(fullFilename) {
-
-  // Initialize
-  var t = this,
-      extension = fullFilename.substr(fullFilename.lastIndexOf('.') + 1),
+  var t = this,  // Initialize
       configObject = null,
       fileContent = null,
       stat = null;
@@ -771,9 +744,7 @@ util.parseFile = function(fullFilename) {
       }
     }
 
-    if (typeof util.parsers[extension] === 'function') {
-      configObject = util.parsers[extension](fullFilename, fileContent);
-    }
+    configObject = Parser.parse(fullFilename, fileContent);
   }
   catch (e3) {
     if (gitCryptTestRegex.test(fileContent)) {
@@ -821,176 +792,11 @@ util.parseFile = function(fullFilename) {
  * @return {configObject} The configuration object parsed from the string
  */
 util.parseString = function (content, format) {
-  if (typeof util.parsers[format] === 'function') {
-    return util.parsers[format](null, content)
+  var parser = Parser.getParser(format);
+  if (typeof parser === 'function') {
+    return parser(null, content);
   }
 };
-
-util.xmlParser = function(filename, content) {
-  if (!XML) {
-    XML = require(XML_DEP);
-  }
-  var x2js = new XML();
-  var configObject = x2js.xml2js(content);
-  var rootKeys = Object.keys(configObject);
-  if(rootKeys.length === 1) {
-    return configObject[rootKeys[0]];
-  }
-  return configObject;
-};
-
-util.jsParser = function(filename, content) {
-  return require(filename);
-};
-
-util.tsParser = function(filename, content) {
-  if (!require.extensions['.ts']) {
-    require(TS_DEP).register({
-      lazy: true,
-      compilerOptions: {
-        allowJs: true,
-      }
-    });
-  }
-
-  // Imports config if it is exported via module.exports = ...
-  // See https://github.com/lorenwest/node-config/issues/524
-  var configObject = require(filename);
-
-  // Because of ES6 modules usage, `default` is treated as named export (like any other)
-  // Therefore config is a value of `default` key.
-  if (configObject.default) {
-    return configObject.default
-  }
-  return configObject;
-};
-
-util.coffeeParser = function(filename, content) {
-  // .coffee files can be loaded with either coffee-script or iced-coffee-script.
-  // Prefer iced-coffee-script, if it exists.
-  // Lazy load the appropriate extension
-  if (!Coffee) {
-    Coffee = {};
-
-    // The following enables iced-coffee-script on .coffee files, if iced-coffee-script is available.
-    // This is commented as per a decision on a pull request.
-    //try {
-    //  Coffee = require("iced-coffee-script");
-    //}
-    //catch (e) {
-    //  Coffee = require("coffee-script");
-    //}
-    try {
-      // Try to load coffeescript
-      Coffee = require(COFFEE_2_DEP);
-    }
-    catch (e) {
-      // If it doesn't exist, try to load it using the deprecated module name
-      Coffee = require(COFFEE_DEP);
-    }
-    // coffee-script >= 1.7.0 requires explicit registration for require() to work
-    if (Coffee.register) {
-      Coffee.register();
-    }
-  }
-  // Use the built-in parser for .coffee files with coffee-script
-  return require(filename);
-};
-
-util.icedParser = function(filename, content) {
-  Iced = require(ICED_DEP);
-
-  // coffee-script >= 1.7.0 requires explicit registration for require() to work
-  if (Iced.register) {
-    Iced.register();
-  }
-};
-
-util.yamlParser = function(filename, content) {
-  if (!Yaml && !VisionmediaYaml) {
-    // Lazy loading
-    try {
-      // Try to load the better js-yaml module
-      Yaml = require(JS_YAML_DEP);
-    }
-    catch (e) {
-      try {
-        // If it doesn't exist, load the fallback visionmedia yaml module.
-        VisionmediaYaml = require(YAML_DEP);
-      }
-      catch (e) { }
-    }
-  }
-  if (Yaml) {
-    return Yaml.load(content);
-  }
-  else if (VisionmediaYaml) {
-    // The yaml library doesn't like strings that have newlines but don't
-    // end in a newline: https://github.com/visionmedia/js-yaml/issues/issue/13
-    content += '\n';
-    return VisionmediaYaml.eval(util.stripYamlComments(content));
-  }
-  else {
-    console.error("No YAML parser loaded.  Suggest adding js-yaml dependency to your package.json file.")
-  }
-};
-
-util.jsonParser = function(filename, content) {
-  try {
-    return JSON.parse(content);
-  }
-  catch (e) {
-    // All JS Style comments will begin with /, so all JSON parse errors that
-    // encountered a syntax error will complain about this character.
-    if (e.name !== 'SyntaxError' || e.message.indexOf('Unexpected token /') !== 0) {
-      throw e;
-    }
-    if (!JSON5) {
-      JSON5 = require(JSON5_DEP);
-    }
-    return JSON5.parse(content);
-  }
-};
-
-util.json5Parser = function(filename, content) {
-  if (!JSON5) {
-    JSON5 = require(JSON5_DEP);
-  }
-  return JSON5.parse(content);
-};
-
-util.hjsonParser = function(filename, content) {
-  if (!HJSON) {
-    HJSON = require(HJSON_DEP);
-  }
-  return HJSON.parse(content);
-};
-
-util.tomlParser = function(filename, content) {
-  if(!TOML) {
-    TOML = require(TOML_DEP);
-  }
-  return TOML.parse(content);
-};
-
-util.csonParser = function(filename, content) {
-  if (!CSON) {
-    CSON = require(CSON_DEP);
-  }
-  // Allow comments in CSON files
-  if (typeof CSON.parseSync === 'function') {
-    return CSON.parseSync(util.stripComments(content));
-  }
-  return CSON.parse(util.stripComments(content));
-};
-
-util.propertiesParser = function(filename, content) {
-  if (!PPARSER) {
-    PPARSER = require(PPARSER_DEP);
-  }
-  return PPARSER.parse(content, { namespaces: true, variables: true, sections: true });
-};
-
 
 /**
  * Attach the Config class prototype to all config objects recursively.
@@ -1412,88 +1218,6 @@ util.extendDeep = function(mergeInto) {
 };
 
 /**
- * Strip YAML comments from the string
- *
- * The 2.0 yaml parser doesn't allow comment-only or blank lines.  Strip them.
- *
- * @protected
- * @method stripYamlComments
- * @param fileString {string} The string to strip comments from
- * @return {string} The string with comments stripped.
- */
-util.stripYamlComments = function(fileStr) {
-  // First replace removes comment-only lines
-  // Second replace removes blank lines
-  return fileStr.replace(/^\s*#.*/mg,'').replace(/^\s*[\n|\r]+/mg,'');
-}
-
-/**
- * Strip all Javascript type comments from the string.
- *
- * The string is usually a file loaded from the O/S, containing
- * newlines and javascript type comments.
- *
- * Thanks to James Padolsey, and all who contributed to this implementation.
- * http://james.padolsey.com/javascript/javascript-comment-removal-revisted/
- *
- * @protected
- * @method stripComments
- * @param fileString {string} The string to strip comments from
- * @param stringRegex {RegExp} Optional regular expression to match strings that
- *   make up the config file
- * @return {string} The string with comments stripped.
- */
-util.stripComments = function(fileStr, stringRegex) {
-  stringRegex = stringRegex || /(['"])(\\\1|.)+?\1/g;
-
-  var uid = '_' + +new Date(),
-      primitives = [],
-      primIndex = 0;
-
-  return (
-    fileStr
-
-    /* Remove strings */
-    .replace(stringRegex, function(match){
-      primitives[primIndex] = match;
-      return (uid + '') + primIndex++;
-    })
-
-    /* Remove Regexes */
-    .replace(/([^\/])(\/(?!\*|\/)(\\\/|.)+?\/[gim]{0,3})/g, function(match, $1, $2){
-      primitives[primIndex] = $2;
-      return $1 + (uid + '') + primIndex++;
-    })
-
-    /*
-    - Remove single-line comments that contain would-be multi-line delimiters
-        E.g. // Comment /* <--
-    - Remove multi-line comments that contain would be single-line delimiters
-        E.g. /* // <--
-   */
-    .replace(/\/\/.*?\/?\*.+?(?=\n|\r|$)|\/\*[\s\S]*?\/\/[\s\S]*?\*\//g, '')
-
-    /*
-    Remove single and multi-line comments,
-    no consideration of inner-contents
-   */
-    .replace(/\/\/.+?(?=\n|\r|$)|\/\*[\s\S]+?\*\//g, '')
-
-    /*
-    Remove multi-line comments that have a replaced ending (string/regex)
-    Greedy, so no inner strings/regexes will stop it.
-   */
-    .replace(RegExp('\\/\\*[\\s\\S]+' + uid + '\\d+', 'g'), '')
-
-    /* Bring back strings & regexes */
-    .replace(RegExp(uid + '(\\d+)', 'g'), function(match, n){
-      return primitives[n];
-    })
-  );
-
-};
-
-/**
  * Is the specified argument a regular javascript object?
  *
  * The argument is an object if it's a JS object, but not an array.
@@ -1644,45 +1368,14 @@ util.runStrictnessChecks = function (config) {
       throw new Error(prefix+msg+' '+seeURL);
     }
   }
-}
-
-util.setParser = function(name, parser, prepend) {
-  util.parsers[name] = parser;
-  if (prepend) {
-    util.parsers.autoloadOrder.unshift(name);
-  } else {
-    util.parsers.autoloadOrder.push(name);
-  }
-};
-
-util.removeParser = function(name) {
-  if (util.parsers[name]) {
-    delete util.parsers[name];
-    var order = util.parsers.autoloadOrder;
-    order.splice(order.indexOf(name), 1);
-  }
-};
-
-util.parsers = {
-  yaml: util.yamlParser,
-  yml: util.yamlParser,
-  js: util.jsParser,
-  ts: util.tsParser,
-  coffee: util.coffeeParser,
-  iced: util.icedParser,
-  json: util.jsonParser,
-  json5: util.json5Parser,
-  hjson: util.hjsonParser,
-  toml: util.tomlParser,
-  cson: util.csonParser,
-  properties: util.propertiesParser,
-  xml: util.xmlParser,
-
-  autoloadOrder: ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'],
 };
 
 // Instantiate and export the configuration
 var config = module.exports = new Config();
+
+// copy methods to util for backwards compatibility
+util.stripComments = Parser.stripComments;
+util.stripYamlComments = Parser.stripYamlComments;
 
 // Produce warnings if the configuration is empty
 var showWarnings = !(util.initParam('SUPPRESS_NO_CONFIG_WARNING'));

--- a/lib/config.js
+++ b/lib/config.js
@@ -585,7 +585,7 @@ util.loadFileConfigs = function(configDir) {
   });
 
 
-  var extNames = Parser.getParserOrder();
+  var extNames = Parser.getFilesOrder();
   baseNames.forEach(function(baseName) {
     extNames.forEach(function(extName) {
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -129,7 +129,9 @@ var Config = function() {
 
   // Bind all utility functions to this
   for (var fnName in util) {
-    util[fnName] = util[fnName].bind(t);
+    if (typeof util[fnName] === 'function') {
+      util[fnName] = util[fnName].bind(t);
+    }
   }
 
   // Merge configurations into this
@@ -591,7 +593,8 @@ util.loadFileConfigs = function(configDir) {
     baseNames.push('local', 'local-' + env);
   });
 
-  var extNames = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
+
+  var extNames = util.parsers.autoloadOrder;
   baseNames.forEach(function(baseName) {
     extNames.forEach(function(extName) {
 
@@ -768,73 +771,8 @@ util.parseFile = function(fullFilename) {
       }
     }
 
-    if (extension === 'js') {
-      // Use the built-in parser for .js files
-      configObject = require(fullFilename);
-    }
-    else if (extension === 'ts') {
-      if (!require.extensions['.ts']) {
-        require(TS_DEP).register({
-          lazy: true,
-          compilerOptions: {
-            allowJs: true,
-          }
-        });
-      }
-
-      // Imports config if it is exported via module.exports = ...
-      // See https://github.com/lorenwest/node-config/issues/524
-      configObject = require(fullFilename)
-
-      // Because of ES6 modules usage, `default` is treated as named export (like any other)
-      // Therefore config is a value of `default` key.
-      if (configObject.default) {
-        configObject = configObject.default
-      }
-    }
-    else if (extension === 'coffee') {
-      // .coffee files can be loaded with either coffee-script or iced-coffee-script.
-      // Prefer iced-coffee-script, if it exists.
-      // Lazy load the appropriate extension
-      if (!Coffee) {
-        Coffee = {};
-
-        // The following enables iced-coffee-script on .coffee files, if iced-coffee-script is available.
-        // This is commented as per a decision on a pull request.
-        //try {
-        //  Coffee = require("iced-coffee-script");
-        //}
-        //catch (e) {
-        //  Coffee = require("coffee-script");
-        //}
-
-        try {
-          // Try to load coffeescript
-          Coffee = require(COFFEE_2_DEP);
-        }
-        catch (e) {
-          // If it doesn't exist, try to load it using the deprecated module name
-          Coffee = require(COFFEE_DEP);
-        }
-
-        // coffee-script >= 1.7.0 requires explicit registration for require() to work
-        if (Coffee.register) {
-          Coffee.register();
-        }
-      }
-      // Use the built-in parser for .coffee files with coffee-script
-      configObject = require(fullFilename);
-    }
-    else if (extension === 'iced') {
-      Iced = require(ICED_DEP);
-
-      // coffee-script >= 1.7.0 requires explicit registration for require() to work
-      if (Iced.register) {
-        Iced.register();
-      }
-    }
-    else {
-      configObject = util.parseString(fileContent, extension);
+    if (typeof util.parsers[extension] === 'function') {
+      configObject = util.parsers[extension](fullFilename, fileContent);
     }
   }
   catch (e3) {
@@ -883,113 +821,176 @@ util.parseFile = function(fullFilename) {
  * @return {configObject} The configuration object parsed from the string
  */
 util.parseString = function (content, format) {
-  // Initialize
-  var configObject = null;
-
-  // Parse the file based on extension
-  if (format === 'yaml' || format === 'yml') {
-    if (!Yaml && !VisionmediaYaml) {
-      // Lazy loading
-      try {
-        // Try to load the better js-yaml module
-        Yaml = require(JS_YAML_DEP);
-      }
-      catch (e) {
-        try {
-          // If it doesn't exist, load the fallback visionmedia yaml module.
-          VisionmediaYaml = require(YAML_DEP);
-        }
-        catch (e) { }
-      }
-    }
-
-    if (Yaml) {
-      configObject = Yaml.load(content);
-    }
-    else if (VisionmediaYaml) {
-      // The yaml library doesn't like strings that have newlines but don't
-      // end in a newline: https://github.com/visionmedia/js-yaml/issues/issue/13
-      content += '\n';
-      configObject = VisionmediaYaml.eval(util.stripYamlComments(content));
-    }
-    else {
-      console.error("No YAML parser loaded.  Suggest adding js-yaml dependency to your package.json file.")
-    }
+  if (typeof util.parsers[format] === 'function') {
+    return util.parsers[format](null, content)
   }
-  else if (format === 'json') {
+};
+
+util.xmlParser = function(filename, content) {
+  if (!XML) {
+    XML = require(XML_DEP);
+  }
+  var x2js = new XML();
+  var configObject = x2js.xml2js(content);
+  var rootKeys = Object.keys(configObject);
+  if(rootKeys.length === 1) {
+    return configObject[rootKeys[0]];
+  }
+  return configObject;
+};
+
+util.jsParser = function(filename, content) {
+  return require(filename);
+};
+
+util.tsParser = function(filename, content) {
+  if (!require.extensions['.ts']) {
+    require(TS_DEP).register({
+      lazy: true,
+      compilerOptions: {
+        allowJs: true,
+      }
+    });
+  }
+
+  // Imports config if it is exported via module.exports = ...
+  // See https://github.com/lorenwest/node-config/issues/524
+  var configObject = require(filename);
+
+  // Because of ES6 modules usage, `default` is treated as named export (like any other)
+  // Therefore config is a value of `default` key.
+  if (configObject.default) {
+    return configObject.default
+  }
+  return configObject;
+};
+
+util.coffeeParser = function(filename, content) {
+  // .coffee files can be loaded with either coffee-script or iced-coffee-script.
+  // Prefer iced-coffee-script, if it exists.
+  // Lazy load the appropriate extension
+  if (!Coffee) {
+    Coffee = {};
+
+    // The following enables iced-coffee-script on .coffee files, if iced-coffee-script is available.
+    // This is commented as per a decision on a pull request.
+    //try {
+    //  Coffee = require("iced-coffee-script");
+    //}
+    //catch (e) {
+    //  Coffee = require("coffee-script");
+    //}
     try {
-      configObject = JSON.parse(content);
+      // Try to load coffeescript
+      Coffee = require(COFFEE_2_DEP);
     }
     catch (e) {
-      // All JS Style comments will begin with /, so all JSON parse errors that
-      // encountered a syntax error will complain about this character.
-      if (e.name !== 'SyntaxError' || e.message.indexOf('Unexpected token /') !== 0) {
-        throw e;
-      }
-
-      if (!JSON5) {
-        JSON5 = require(JSON5_DEP);
-      }
-
-      configObject = JSON5.parse(content);
+      // If it doesn't exist, try to load it using the deprecated module name
+      Coffee = require(COFFEE_DEP);
+    }
+    // coffee-script >= 1.7.0 requires explicit registration for require() to work
+    if (Coffee.register) {
+      Coffee.register();
     }
   }
-  else if (format === 'json5') {
+  // Use the built-in parser for .coffee files with coffee-script
+  return require(filename);
+};
 
+util.icedParser = function(filename, content) {
+  Iced = require(ICED_DEP);
+
+  // coffee-script >= 1.7.0 requires explicit registration for require() to work
+  if (Iced.register) {
+    Iced.register();
+  }
+};
+
+util.yamlParser = function(filename, content) {
+  if (!Yaml && !VisionmediaYaml) {
+    // Lazy loading
+    try {
+      // Try to load the better js-yaml module
+      Yaml = require(JS_YAML_DEP);
+    }
+    catch (e) {
+      try {
+        // If it doesn't exist, load the fallback visionmedia yaml module.
+        VisionmediaYaml = require(YAML_DEP);
+      }
+      catch (e) { }
+    }
+  }
+  if (Yaml) {
+    return Yaml.load(content);
+  }
+  else if (VisionmediaYaml) {
+    // The yaml library doesn't like strings that have newlines but don't
+    // end in a newline: https://github.com/visionmedia/js-yaml/issues/issue/13
+    content += '\n';
+    return VisionmediaYaml.eval(util.stripYamlComments(content));
+  }
+  else {
+    console.error("No YAML parser loaded.  Suggest adding js-yaml dependency to your package.json file.")
+  }
+};
+
+util.jsonParser = function(filename, content) {
+  try {
+    return JSON.parse(content);
+  }
+  catch (e) {
+    // All JS Style comments will begin with /, so all JSON parse errors that
+    // encountered a syntax error will complain about this character.
+    if (e.name !== 'SyntaxError' || e.message.indexOf('Unexpected token /') !== 0) {
+      throw e;
+    }
     if (!JSON5) {
       JSON5 = require(JSON5_DEP);
     }
-
-    configObject = JSON5.parse(content);
-
-  } else if (format === 'hjson') {
-
-    if (!HJSON) {
-      HJSON = require(HJSON_DEP);
-    }
-
-    configObject = HJSON.parse(content);
-
-  } else if (format === 'toml') {
-
-    if(!TOML) {
-      TOML = require(TOML_DEP);
-    }
-
-    configObject = TOML.parse(content);
+    return JSON5.parse(content);
   }
-  else if (format === 'cson') {
-    if (!CSON) {
-      CSON = require(CSON_DEP);
-    }
-    // Allow comments in CSON files
-    if (typeof CSON.parseSync === 'function') {
-      configObject = CSON.parseSync(util.stripComments(content));
-    } else {
-      configObject = CSON.parse(util.stripComments(content));
-    }
-  }
-  else if (format === 'properties') {
-    if (!PPARSER) {
-      PPARSER = require(PPARSER_DEP);
-    }
-    configObject = PPARSER.parse(content, { namespaces: true, variables: true, sections: true });
-  } else if (format === 'xml') {
-
-    if (!XML) {
-      XML = require(XML_DEP);
-    }
-
-    var x2js = new XML();
-    configObject = x2js.xml2js(content);
-    var rootKeys = Object.keys(configObject);
-    if(rootKeys.length == 1) {
-      configObject = configObject[rootKeys[0]];
-    }
-  }
-
-  return configObject;
 };
+
+util.json5Parser = function(filename, content) {
+  if (!JSON5) {
+    JSON5 = require(JSON5_DEP);
+  }
+  return JSON5.parse(content);
+};
+
+util.hjsonParser = function(filename, content) {
+  if (!HJSON) {
+    HJSON = require(HJSON_DEP);
+  }
+  return HJSON.parse(content);
+};
+
+util.tomlParser = function(filename, content) {
+  if(!TOML) {
+    TOML = require(TOML_DEP);
+  }
+  return TOML.parse(content);
+};
+
+util.csonParser = function(filename, content) {
+  if (!CSON) {
+    CSON = require(CSON_DEP);
+  }
+  // Allow comments in CSON files
+  if (typeof CSON.parseSync === 'function') {
+    return CSON.parseSync(util.stripComments(content));
+  }
+  return CSON.parse(util.stripComments(content));
+};
+
+util.propertiesParser = function(filename, content) {
+  if (!PPARSER) {
+    PPARSER = require(PPARSER_DEP);
+  }
+  return PPARSER.parse(content, { namespaces: true, variables: true, sections: true });
+};
+
 
 /**
  * Attach the Config class prototype to all config objects recursively.
@@ -1644,6 +1645,41 @@ util.runStrictnessChecks = function (config) {
     }
   }
 }
+
+util.setParser = function(name, parser, prepend) {
+  util.parsers[name] = parser;
+  if (prepend) {
+    util.parsers.autoloadOrder.unshift(name);
+  } else {
+    util.parsers.autoloadOrder.push(name);
+  }
+};
+
+util.removeParser = function(name) {
+  if (util.parsers[name]) {
+    delete util.parsers[name];
+    var order = util.parsers.autoloadOrder;
+    order.splice(order.indexOf(name), 1);
+  }
+};
+
+util.parsers = {
+  yaml: util.yamlParser,
+  yml: util.yamlParser,
+  js: util.jsParser,
+  ts: util.tsParser,
+  coffee: util.coffeeParser,
+  iced: util.icedParser,
+  json: util.jsonParser,
+  json5: util.json5Parser,
+  hjson: util.hjsonParser,
+  toml: util.tomlParser,
+  cson: util.csonParser,
+  properties: util.propertiesParser,
+  xml: util.xmlParser,
+
+  autoloadOrder: ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'],
+};
 
 // Instantiate and export the configuration
 var config = module.exports = new Config();

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,6 +16,7 @@ var deferConfig = require('../defer').deferConfig,
 var DEFAULT_CLONE_DEPTH = 20,
     NODE_CONFIG, CONFIG_DIR, RUNTIME_JSON_FILENAME, NODE_ENV, APP_INSTANCE,
     HOST, HOSTNAME, ALLOW_CONFIG_MUTATIONS, CONFIG_SKIP_GITCRYPT,
+    NODE_CONFIG_PARSER,
     env = {},
     privateUtil = {},
     deprecationWarnings = {},
@@ -531,6 +532,20 @@ util.loadFileConfigs = function(configDir) {
   // This is for backward compatibility
   RUNTIME_JSON_FILENAME = util.initParam('NODE_CONFIG_RUNTIME_JSON', Path.join(CONFIG_DIR , 'runtime.json') );
 
+  NODE_CONFIG_PARSER = util.initParam('NODE_CONFIG_PARSER');
+  if (NODE_CONFIG_PARSER) {
+    try {
+      var parserModule = Path.isAbsolute(NODE_CONFIG_PARSER)
+        ? NODE_CONFIG_PARSER
+        : Path.join(CONFIG_DIR, NODE_CONFIG_PARSER);
+      Parser = require(parserModule);
+    }
+    catch (e) {
+      console.warn('Failed to load config parser from ' + NODE_CONFIG_PARSER);
+      console.log(e);
+    }
+  }
+
   // Determine the host name from the OS module, $HOST, or $HOSTNAME
   // Remove any . appendages, and default to null if not set
   try {
@@ -570,7 +585,7 @@ util.loadFileConfigs = function(configDir) {
   });
 
 
-  var extNames = Parser.getOrder();
+  var extNames = Parser.getParserOrder();
   baseNames.forEach(function(baseName) {
     extNames.forEach(function(extName) {
 
@@ -661,9 +676,9 @@ util.resolveDeferredConfigs = function (config) {
 
     // Second step is to iterate of the elements in a predictable (sorted) order
     propsToSort.sort().forEach(function (property) {
-      if (prop[property].constructor == Object) {
+      if (prop[property].constructor === Object) {
         _iterate(prop[property]);
-      } else if (prop[property].constructor == Array) {
+      } else if (prop[property].constructor === Array) {
         for (var i = 0; i < prop[property].length; i++) {
           _iterate(prop[property][i]);
         }
@@ -704,7 +719,7 @@ util.resolveDeferredConfigs = function (config) {
  * @protected
  * @method parseFile
  * @param fullFilename {string} The full file path and name
- * @return {configObject} The configuration object parsed from the file
+ * @return configObject {object|null} The configuration object parsed from the file
  */
 util.parseFile = function(fullFilename) {
   var t = this,  // Initialize

--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,345 @@
+// External libraries are lazy-loaded only if these file types exist.
+var Yaml = null,
+    VisionmediaYaml = null,
+    Coffee = null,
+    Iced = null,
+    CSON = null,
+    PPARSER = null,
+    JSON5 = null,
+    TOML = null,
+    HJSON = null,
+    XML = null;
+
+// Define soft dependencies so transpilers don't include everything
+var COFFEE_2_DEP = 'coffeescript',
+    COFFEE_DEP = 'coffee-script',
+    ICED_DEP = 'iced-coffee-script',
+    JS_YAML_DEP = 'js-yaml',
+    YAML_DEP = 'yaml',
+    JSON5_DEP = 'json5',
+    HJSON_DEP = 'hjson',
+    TOML_DEP = 'toml',
+    CSON_DEP = 'cson',
+    PPARSER_DEP = 'properties',
+    XML_DEP = 'x2js',
+    TS_DEP = 'ts-node';
+
+var Parser = module.exports;
+
+Parser.parse = function(filename, content) {
+  var parserName = filename.substr(filename.lastIndexOf('.') +1);  // file extension
+  if (typeof definitions[parserName] === 'function') {
+    return definitions[parserName](filename, content);
+  }
+  // TODO: decide what to do in case of a missing parser
+};
+
+Parser.xmlParser = function(filename, content) {
+  if (!XML) {
+    XML = require(XML_DEP);
+  }
+  var x2js = new XML();
+  var configObject = x2js.xml2js(content);
+  var rootKeys = Object.keys(configObject);
+  if(rootKeys.length === 1) {
+    return configObject[rootKeys[0]];
+  }
+  return configObject;
+};
+
+Parser.jsParser = function(filename, content) {
+  return require(filename);
+};
+
+Parser.tsParser = function(filename, content) {
+  if (!require.extensions['.ts']) {
+    require(TS_DEP).register({
+      lazy: true,
+      compilerOptions: {
+        allowJs: true,
+      }
+    });
+  }
+
+  // Imports config if it is exported via module.exports = ...
+  // See https://github.com/lorenwest/node-config/issues/524
+  var configObject = require(filename);
+
+  // Because of ES6 modules usage, `default` is treated as named export (like any other)
+  // Therefore config is a value of `default` key.
+  if (configObject.default) {
+    return configObject.default
+  }
+  return configObject;
+};
+
+Parser.coffeeParser = function(filename, content) {
+  // .coffee files can be loaded with either coffee-script or iced-coffee-script.
+  // Prefer iced-coffee-script, if it exists.
+  // Lazy load the appropriate extension
+  if (!Coffee) {
+    Coffee = {};
+
+    // The following enables iced-coffee-script on .coffee files, if iced-coffee-script is available.
+    // This is commented as per a decision on a pull request.
+    //try {
+    //  Coffee = require('iced-coffee-script');
+    //}
+    //catch (e) {
+    //  Coffee = require('coffee-script');
+    //}
+    try {
+      // Try to load coffeescript
+      Coffee = require(COFFEE_2_DEP);
+    }
+    catch (e) {
+      // If it doesn't exist, try to load it using the deprecated module name
+      Coffee = require(COFFEE_DEP);
+    }
+    // coffee-script >= 1.7.0 requires explicit registration for require() to work
+    if (Coffee.register) {
+      Coffee.register();
+    }
+  }
+  // Use the built-in parser for .coffee files with coffee-script
+  return require(filename);
+};
+
+Parser.icedParser = function(filename, content) {
+  Iced = require(ICED_DEP);
+
+  // coffee-script >= 1.7.0 requires explicit registration for require() to work
+  if (Iced.register) {
+    Iced.register();
+  }
+};
+
+Parser.yamlParser = function(filename, content) {
+  if (!Yaml && !VisionmediaYaml) {
+    // Lazy loading
+    try {
+      // Try to load the better js-yaml module
+      Yaml = require(JS_YAML_DEP);
+    }
+    catch (e) {
+      try {
+        // If it doesn't exist, load the fallback visionmedia yaml module.
+        VisionmediaYaml = require(YAML_DEP);
+      }
+      catch (e) { }
+    }
+  }
+  if (Yaml) {
+    return Yaml.load(content);
+  }
+  else if (VisionmediaYaml) {
+    // The yaml library doesn't like strings that have newlines but don't
+    // end in a newline: https://github.com/visionmedia/js-yaml/issues/issue/13
+    content += '\n';
+    return VisionmediaYaml.eval(Parser.stripYamlComments(content));
+  }
+  else {
+    console.error('No YAML parser loaded.  Suggest adding js-yaml dependency to your package.json file.')
+  }
+};
+
+Parser.jsonParser = function(filename, content) {
+  try {
+    return JSON.parse(content);
+  }
+  catch (e) {
+    // All JS Style comments will begin with /, so all JSON parse errors that
+    // encountered a syntax error will complain about this character.
+    if (e.name !== 'SyntaxError' || e.message.indexOf('Unexpected token /') !== 0) {
+      throw e;
+    }
+    if (!JSON5) {
+      JSON5 = require(JSON5_DEP);
+    }
+    return JSON5.parse(content);
+  }
+};
+
+Parser.json5Parser = function(filename, content) {
+  if (!JSON5) {
+    JSON5 = require(JSON5_DEP);
+  }
+  return JSON5.parse(content);
+};
+
+Parser.hjsonParser = function(filename, content) {
+  if (!HJSON) {
+    HJSON = require(HJSON_DEP);
+  }
+  return HJSON.parse(content);
+};
+
+Parser.tomlParser = function(filename, content) {
+  if(!TOML) {
+    TOML = require(TOML_DEP);
+  }
+  return TOML.parse(content);
+};
+
+Parser.csonParser = function(filename, content) {
+  if (!CSON) {
+    CSON = require(CSON_DEP);
+  }
+  // Allow comments in CSON files
+  if (typeof CSON.parseSync === 'function') {
+    return CSON.parseSync(Parser.stripComments(content));
+  }
+  return CSON.parse(Parser.stripComments(content));
+};
+
+Parser.propertiesParser = function(filename, content) {
+  if (!PPARSER) {
+    PPARSER = require(PPARSER_DEP);
+  }
+  return PPARSER.parse(content, { namespaces: true, variables: true, sections: true });
+};
+
+/**
+ * Strip all Javascript type comments from the string.
+ *
+ * The string is usually a file loaded from the O/S, containing
+ * newlines and javascript type comments.
+ *
+ * Thanks to James Padolsey, and all who contributed to this implementation.
+ * http://james.padolsey.com/javascript/javascript-comment-removal-revisted/
+ *
+ * @protected
+ * @method stripComments
+ * @param fileStr {string} The string to strip comments from
+ * @param stringRegex {RegExp} Optional regular expression to match strings that
+ *   make up the config file
+ * @return {string} The string with comments stripped.
+ */
+Parser.stripComments = function(fileStr, stringRegex) {
+  stringRegex = stringRegex || /(['"])(\\\1|.)+?\1/g;
+
+  var uid = '_' + +new Date(),
+    primitives = [],
+    primIndex = 0;
+
+  return (
+    fileStr
+
+    /* Remove strings */
+      .replace(stringRegex, function(match){
+        primitives[primIndex] = match;
+        return (uid + '') + primIndex++;
+      })
+
+      /* Remove Regexes */
+      .replace(/([^\/])(\/(?!\*|\/)(\\\/|.)+?\/[gim]{0,3})/g, function(match, $1, $2){
+        primitives[primIndex] = $2;
+        return $1 + (uid + '') + primIndex++;
+      })
+
+      /*
+      - Remove single-line comments that contain would-be multi-line delimiters
+          E.g. // Comment /* <--
+      - Remove multi-line comments that contain would be single-line delimiters
+          E.g. /* // <--
+     */
+      .replace(/\/\/.*?\/?\*.+?(?=\n|\r|$)|\/\*[\s\S]*?\/\/[\s\S]*?\*\//g, '')
+
+      /*
+      Remove single and multi-line comments,
+      no consideration of inner-contents
+     */
+      .replace(/\/\/.+?(?=\n|\r|$)|\/\*[\s\S]+?\*\//g, '')
+
+      /*
+      Remove multi-line comments that have a replaced ending (string/regex)
+      Greedy, so no inner strings/regexes will stop it.
+     */
+      .replace(RegExp('\\/\\*[\\s\\S]+' + uid + '\\d+', 'g'), '')
+
+      /* Bring back strings & regexes */
+      .replace(RegExp(uid + '(\\d+)', 'g'), function(match, n){
+        return primitives[n];
+      })
+  );
+
+};
+
+/**
+ * Strip YAML comments from the string
+ *
+ * The 2.0 yaml parser doesn't allow comment-only or blank lines.  Strip them.
+ *
+ * @protected
+ * @method stripYamlComments
+ * @param fileStr {string} The string to strip comments from
+ * @return {string} The string with comments stripped.
+ */
+Parser.stripYamlComments = function(fileStr) {
+  // First replace removes comment-only lines
+  // Second replace removes blank lines
+  return fileStr.replace(/^\s*#.*/mg,'').replace(/^\s*[\n|\r]+/mg,'');
+};
+
+var order = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
+var definitions = {
+  coffee: Parser.coffeeParser,
+  cson: Parser.csonParser,
+  hjson: Parser.hjsonParser,
+  iced: Parser.icedParser,
+  js: Parser.jsParser,
+  json: Parser.jsonParser,
+  json5: Parser.json5Parser,
+  properties: Parser.propertiesParser,
+  toml: Parser.tomlParser,
+  ts: Parser.tsParser,
+  xml: Parser.xmlParser,
+  yaml: Parser.yamlParser,
+  yml: Parser.yamlParser,
+};
+
+Parser.getOrder = function(name) {
+  if (name) {
+    return order.indexOf(name);
+  }
+  return order;
+};
+
+Parser.setOrder = function(name, index) {
+  if (Array.isArray(name)) {
+    order = name;
+    return order;
+  }
+  var curIndex = order.indexOf(name);
+  order.splice(index, 0, name);
+  order.splice(curIndex >= index ? curIndex +1 : curIndex, 1);
+  return order;
+};
+
+Parser.unsetOrder = function(name) {
+  order.splice(order.indexOf(name), 1);
+  return order;
+};
+
+Parser.getParser = function(name) {
+  return definitions[name];
+};
+
+Parser.setParser = function(name, parser) {
+  if (!definitions[name]) {
+    order.push(name);
+  }
+  definitions[name] = parser;
+};
+
+Parser.unsetParser = function(name) {
+  if (name) {
+    if (definitions[name]) {
+      order.splice(order.indexOf(name), 1);
+    }
+    delete definitions[name];
+  } else {
+    order = [];
+    definitions = {};
+  }
+};

--- a/parser.js
+++ b/parser.js
@@ -309,37 +309,23 @@ Parser.setParser = function(name, parser) {
   }
 };
 
-Parser.getParserOrder = function(name) {
+Parser.getFilesOrder = function(name) {
   if (name) {
     return order.indexOf(name);
   }
   return order;
 };
 
-Parser.setParserOrder = function(name, newIndex) {
+Parser.setFilesOrder = function(name, newIndex) {
   if (Array.isArray(name)) {
     return order = name;
   }
-  var index = order.indexOf(name);
   if (typeof newIndex === 'number') {
-    order.splice(newIndex, 0, name);
-  } else {
-    newIndex = order.push(name) -1;
-  }
-  if (index > -1) {
-    order.splice(index >= newIndex ? index +1 : index, 1);
-  }
-  return order;
-};
-
-Parser.unsetParserOrder = function(name) {
-  if (name) {
     var index = order.indexOf(name);
+    order.splice(newIndex, 0, name);
     if (index > -1) {
-      order.splice(index, 1);
+      order.splice(index >= newIndex ? index +1 : index, 1);
     }
-  } else {
-    order = [];
   }
   return order;
 };

--- a/parser.js
+++ b/parser.js
@@ -298,48 +298,48 @@ var definitions = {
   yml: Parser.yamlParser,
 };
 
-Parser.getOrder = function(name) {
+Parser.getParser = function(name) {
+  return definitions[name];
+};
+
+Parser.setParser = function(name, parser) {
+  definitions[name] = parser;
+  if (order.indexOf(name) === -1) {
+    order.push(name);
+  }
+};
+
+Parser.getParserOrder = function(name) {
   if (name) {
     return order.indexOf(name);
   }
   return order;
 };
 
-Parser.setOrder = function(name, index) {
+Parser.setParserOrder = function(name, newIndex) {
   if (Array.isArray(name)) {
-    order = name;
-    return order;
+    return order = name;
   }
-  var curIndex = order.indexOf(name);
-  order.splice(index, 0, name);
-  order.splice(curIndex >= index ? curIndex +1 : curIndex, 1);
+  var index = order.indexOf(name);
+  if (typeof newIndex === 'number') {
+    order.splice(newIndex, 0, name);
+  } else {
+    newIndex = order.push(name) -1;
+  }
+  if (index > -1) {
+    order.splice(index >= newIndex ? index +1 : index, 1);
+  }
   return order;
 };
 
-Parser.unsetOrder = function(name) {
-  order.splice(order.indexOf(name), 1);
-  return order;
-};
-
-Parser.getParser = function(name) {
-  return definitions[name];
-};
-
-Parser.setParser = function(name, parser) {
-  if (!definitions[name]) {
-    order.push(name);
-  }
-  definitions[name] = parser;
-};
-
-Parser.unsetParser = function(name) {
+Parser.unsetParserOrder = function(name) {
   if (name) {
-    if (definitions[name]) {
-      order.splice(order.indexOf(name), 1);
+    var index = order.indexOf(name);
+    if (index > -1) {
+      order.splice(index, 1);
     }
-    delete definitions[name];
   } else {
     order = [];
-    definitions = {};
   }
+  return order;
 };

--- a/test/16-config/default.custom
+++ b/test/16-config/default.custom
@@ -1,0 +1,4 @@
+file-type: custom
+file-name: my-custom-awesome-dsl
+parser: custom-awesomeness
+   custom-key   :     wow!

--- a/test/16-config/default.json
+++ b/test/16-config/default.json
@@ -1,0 +1,7 @@
+{
+  "file": {
+    "type": "json",
+    "name": "default"
+  },
+  "parser": "json"
+}

--- a/test/16-config/default.json5
+++ b/test/16-config/default.json5
@@ -1,0 +1,3 @@
+{
+  parser: "json5",
+}

--- a/test/16-config/default.yaml
+++ b/test/16-config/default.yaml
@@ -1,0 +1,4 @@
+file:
+  type: yaml
+  name: default.yaml
+parser: js-yaml

--- a/test/16-config/local.custom
+++ b/test/16-config/local.custom
@@ -1,0 +1,1 @@
+   custom-key   :     wow!

--- a/test/16-config/local.yml
+++ b/test/16-config/local.yml
@@ -1,0 +1,2 @@
+file:
+  name: local.yml

--- a/test/16-config/parser/custom-1.js
+++ b/test/16-config/parser/custom-1.js
@@ -1,0 +1,22 @@
+var Parser = require('../../_utils/requireUncached')(__dirname + '/../../../parser');
+
+// change parser order
+Parser.setParserOrder('yaml', 0);
+Parser.setParserOrder('yml', 1);
+
+Parser.setParser('custom', function(filename, content) {
+  return content.split(/\n/g).reduce(function(res, line) {
+    var matches = line.match(/([a-z_\-]+)\s*:\s*(.*)\s*$/i);
+    if (matches) {
+      matches[1].split(/-/g).reduce(function(obj, key, index, keys) {
+        if (index === keys.length -1) {
+          obj[key] = matches[2];
+        }
+        return obj[key] || (obj[key] = {});
+      }, res);
+    }
+    return res;
+  }, {});
+});
+
+module.exports = Parser;

--- a/test/16-config/parser/custom-1.js
+++ b/test/16-config/parser/custom-1.js
@@ -1,8 +1,8 @@
 var Parser = require('../../_utils/requireUncached')(__dirname + '/../../../parser');
 
 // change parser order
-Parser.setParserOrder('yaml', 0);
-Parser.setParserOrder('yml', 1);
+Parser.setFilesOrder('yaml', 0);
+Parser.setFilesOrder('yml', 1);
 
 Parser.setParser('custom', function(filename, content) {
   return content.split(/\n/g).reduce(function(res, line) {

--- a/test/16-config/parser/custom-2.js
+++ b/test/16-config/parser/custom-2.js
@@ -16,7 +16,7 @@ Parser.setParser('custom', function(filename, content) {
 });
 
 // change parser order
-Parser.setParserOrder(['custom', 'json5', 'json', 'yml']);
+Parser.setFilesOrder(['custom', 'json5', 'json', 'yml']);
 
 
 module.exports = Parser;

--- a/test/16-config/parser/custom-2.js
+++ b/test/16-config/parser/custom-2.js
@@ -1,0 +1,22 @@
+var Parser = require('../../_utils/requireUncached')(__dirname + '/../../../parser');
+
+Parser.setParser('custom', function(filename, content) {
+  return content.split(/\n/g).reduce(function(res, line) {
+    var matches = line.match(/([a-z_\-]+)\s*:\s*(.*)\s*$/i);
+    if (matches) {
+      matches[1].split(/-/g).reduce(function(obj, key, index, keys) {
+        if (index === keys.length -1) {
+          obj[key] = matches[2];
+        }
+        return obj[key] || (obj[key] = {});
+      }, res);
+    }
+    return res;
+  }, {});
+});
+
+// change parser order
+Parser.setParserOrder(['custom', 'json5', 'json', 'yml']);
+
+
+module.exports = Parser;

--- a/test/16-config/parser/custom-3.js
+++ b/test/16-config/parser/custom-3.js
@@ -6,6 +6,6 @@ Parser.setParser('json5', function(filename, content) {
   return json;
 });
 
-Parser.setParserOrder('json5');
+Parser.setFilesOrder(['yaml', 'yml', 'json5']);
 
 module.exports = Parser;

--- a/test/16-config/parser/custom-3.js
+++ b/test/16-config/parser/custom-3.js
@@ -1,0 +1,11 @@
+var Parser = require('../../_utils/requireUncached')(__dirname + '/../../../parser');
+
+Parser.setParser('json5', function(filename, content) {
+  var json = Parser.json5Parser(filename, content);
+  json.custom = {key: 'json5 rules!'};
+  return json;
+});
+
+Parser.setParserOrder('json5');
+
+module.exports = Parser;

--- a/test/16-custom-parser.js
+++ b/test/16-custom-parser.js
@@ -65,6 +65,10 @@ vows.describe('Tests for a custom parser provided by NODE_CONFIG_PARSER')
         assert.equal(CONFIG.get('parser'), 'json5');
         assert.equal(CONFIG.get('custom.key'), 'json5 rules!');
       },
+    },
+    teardown : function (topic) {
+      delete process.env.NODE_CONFIG_PARSER;
+      requireUncached(__dirname + '/../parser');
     }
   })
   .export(module);

--- a/test/16-custom-parser.js
+++ b/test/16-custom-parser.js
@@ -1,0 +1,70 @@
+var requireUncached = require('./_utils/requireUncached');
+var Parser = require('../parser');
+
+'use strict';
+
+var vows = require('vows'),
+  assert = require('assert');
+
+vows.describe('Tests for a custom parser provided by NODE_CONFIG_PARSER')
+  .addBatch({
+    'Using the default parser - Sanity check': {
+      topic: function() {
+        process.env.NODE_CONFIG_DIR = __dirname + '/16-config';
+        return requireUncached(__dirname + '/../lib/config');
+      },
+      'validate default parser order': function(CONFIG) {
+        assert.equal(CONFIG.get('file.type'), 'yaml');
+        assert.equal(CONFIG.get('file.name'), 'local.yml');
+        assert.equal(CONFIG.get('parser'), 'js-yaml');
+        assert.equal(CONFIG.has('custom.key'), false);
+      },
+    }
+  })
+  .addBatch({
+    'Using setParserOrder to change parsing order': {
+      topic: function() {
+        process.env.NODE_CONFIG_DIR = __dirname + '/16-config';
+        process.env.NODE_CONFIG_PARSER = __dirname + '/16-config/parser/custom-1';
+        return requireUncached(__dirname + '/../lib/config');
+      },
+      'validate changes to parser order': function(CONFIG) {
+        assert.equal(CONFIG.get('file.type'), 'custom');
+        assert.equal(CONFIG.get('file.name'), 'local.yml');
+        // assert.equal(CONFIG.get('file.name'), 'my-custom-awesome-dsl');
+        assert.equal(CONFIG.get('parser'), 'custom-awesomeness');
+        assert.equal(CONFIG.get('custom.key'), 'wow!');
+      },
+    }
+  })
+  .addBatch({
+    'Using setParserOrder to replace parsing order': {
+      topic: function() {
+        process.env.NODE_CONFIG_DIR = __dirname + '/16-config';
+        process.env.NODE_CONFIG_PARSER = __dirname + '/16-config/parser/custom-2';
+        return requireUncached(__dirname + '/../lib/config');
+      },
+      'validate changes to parser order': function(CONFIG) {
+        assert.equal(CONFIG.get('file.type'), 'json');
+        assert.equal(CONFIG.get('file.name'), 'local.yml');
+        assert.equal(CONFIG.get('parser'), 'json');
+        assert.equal(CONFIG.get('custom.key'), 'wow!');
+      },
+    }
+  })
+  .addBatch({
+    'Using setParser to replace a parser': {
+      topic: function() {
+        process.env.NODE_CONFIG_DIR = __dirname + '/16-config';
+        process.env.NODE_CONFIG_PARSER = __dirname + '/16-config/parser/custom-3';
+        return requireUncached(__dirname + '/../lib/config');
+      },
+      'validate changes to parser logic': function(CONFIG) {
+        assert.equal(CONFIG.get('file.type'), 'yaml');
+        assert.equal(CONFIG.get('file.name'), 'local.yml');
+        assert.equal(CONFIG.get('parser'), 'json5');
+        assert.equal(CONFIG.get('custom.key'), 'json5 rules!');
+      },
+    }
+  })
+  .export(module);


### PR DESCRIPTION
This is my initial proposal. 
I just wanna make sure you're okay with this change before moving forward and adding a new env-var which will be loaded and merged with `util.parsers` before loading configuration files.

The only change to logic offered here is the addition of `util.setParser` and `util.removeParser`. 
Everything else should continue working in exactly the same ways as before.

Note: There's a typo in the commit message. Refers to #181 