### PR TITLE
Improved asyncConfig to support new deferConfig mechanism

### DIFF
--- a/async.js
+++ b/async.js
@@ -1,22 +1,35 @@
+var asyncSymbol = Symbol('asyncSymbol');
 var deferConfig = require('./defer').deferConfig;
-
-function AsyncConfig () {}
-AsyncConfig.prototype.getPromise = function () { return Promise.resolve(); };
 
 /**
  * @param promiseOrFunc   the promise will determine a property's value once resolved
  *                        can also be a function to defer which resolves to a promise
- * @returns {AsyncConfig}   a 'async' configuration value to resolve later with `resolveAsyncConfigs`
+ * @returns {Promise}     a marked promise to be resolve later using `resolveAsyncConfigs`
  */
-function asyncConfig (promiseOrFunc) {
+function asyncConfig(promiseOrFunc) {
   if (typeof promiseOrFunc === 'function') {  // also acts as deferConfig
     return deferConfig(function (config, original) {
-      return asyncConfig(promiseOrFunc.call(config, config, original));
+      var release;
+      function registerRelease(resolve) { release = resolve; }
+      function callFunc() { return promiseOrFunc.call(config, config, original); }
+      var promise = asyncConfig(new Promise(registerRelease).then(callFunc));
+      promise.release = release;
+      return promise;
     });
   }
-  var obj = Object.create(AsyncConfig.prototype);
-  obj.getPromise = function() { return promiseOrFunc; };
-  return obj;
+  var promise = promiseOrFunc;
+  promise.async = asyncSymbol;
+  promise.prepare = function(config, prop, property) {
+    if (promise.release) {
+      promise.release();
+    }
+    return function() {
+      return promise.then(function(value) {
+        Object.defineProperty(prop, property, {value: value});
+      });
+    };
+  };
+  return promise;
 }
 
 /**
@@ -26,6 +39,7 @@ function asyncConfig (promiseOrFunc) {
  */
 function resolveAsyncConfigs(config) {
   var promises = [];
+  var resolvers = [];
   (function iterate(prop) {
     var propsToSort = [];
     for (var property in prop) {
@@ -40,20 +54,17 @@ function resolveAsyncConfigs(config) {
       else if (prop[property].constructor === Array) {
         prop[property].forEach(iterate);
       }
-      else if (prop[property] instanceof AsyncConfig) {
-        promises.push(
-          prop[property].getPromise().then(function(val) { prop[property] = val; }, function(err) {
-            prop[property] = undefined;
-            console.error(err);
-          })
-        );
+      else if (prop[property] && prop[property].async === asyncSymbol) {
+        resolvers.push(prop[property].prepare(config, prop, property));
+        promises.push(prop[property]);
       }
     });
   })(config);
-  return Promise.all(promises).then(function() { return config; });
+  return Promise.all(promises).then(function() {
+    resolvers.forEach(function(resolve) { resolve(); });
+    return config;
+  });
 }
 
 module.exports.asyncConfig = asyncConfig;
-module.exports.AsyncConfig = AsyncConfig;
-
 module.exports.resolveAsyncConfigs = resolveAsyncConfigs;

--- a/lib/config.js
+++ b/lib/config.js
@@ -951,6 +951,8 @@ util.cloneDeep = function cloneDeep(parent, depth, circular, prototype) {
 
       if (hasGetter){
         Object.defineProperty(child,i,propDescriptor);
+      } else if (util.isPromise(parent[i])) {
+        child[i] = parent[i];
       } else {
         child[i] = _clone(parent[i], depth - 1);
       }
@@ -1216,9 +1218,11 @@ util.extendDeep = function(mergeInto) {
       } else if (util.isObject(mergeInto[prop]) && util.isObject(mergeFrom[prop]) && !isDeferredFunc) {
         util.extendDeep(mergeInto[prop], mergeFrom[prop], depth - 1);
       }
-
+      else if (util.isPromise(mergeFrom[prop])) {
+        mergeInto[prop] = mergeFrom[prop];
+      }
       // Copy recursively if the mergeFrom element is an object (or array or fn)
-      else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object' && !util.isPromise(mergeFrom[prop])) {
+      else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object') {
         mergeInto[prop] = util.cloneDeep(mergeFrom[prop], depth -1);
       }
 

--- a/test/15-async-configs.js
+++ b/test/15-async-configs.js
@@ -61,5 +61,9 @@ vows.describe('Tests for async values - JavaScript').addBatch({
     "second async promise return local value." : function () {
       assert.equal(CONFIG.original.originalPromise, 'not an original value');
     },
+
+    "verify deferred functionality plays nicely with AsyncConfig." : function () {
+      assert.equal(CONFIG.promiseSubject, 'New Instance! Welcome to New Instance!');
+    },
   }
 }).export(module);

--- a/test/15-config/local.js
+++ b/test/15-config/local.js
@@ -1,7 +1,11 @@
 var asyncConfig = require('../../async').asyncConfig;
 
 var config = {
- siteTitle : 'New Instance!',
+  siteTitle : 'New Instance!',
+  promiseSubject: asyncConfig(async function(cfg) {
+    var subject = await cfg.welcomeEmail.subject;
+    return this.siteTitle+' '+subject;
+  })
 };
 
 config.map = {


### PR DESCRIPTION
Now every async function used by `asyncConfig` is also deferred, which means you can access the resolved config including other asyncConfig promises (or native ones), and dependencies are automatically resolved.

Example:
```
async function dbConfig() {
  // services information and required secrets
}
async function userToken(cfg) {
  const { username, secretKey } = await cfg.dbConfig;
  return await fetchToken(username, secretKey);
}
module.exports = {
  dbConfig: asyncConfig(dbConfig),
  userToken: asyncConfig(userToken),
};
```