### PR TITLE
#560 Improve performance + Support multiple config directories + Fix #512

### DIFF
--- a/async.js
+++ b/async.js
@@ -1,22 +1,35 @@
+var asyncSymbol = Symbol('asyncSymbol');
 var deferConfig = require('./defer').deferConfig;
-
-function AsyncConfig () {}
-AsyncConfig.prototype.getPromise = function () { return Promise.resolve(); };
 
 /**
  * @param promiseOrFunc   the promise will determine a property's value once resolved
  *                        can also be a function to defer which resolves to a promise
- * @returns {AsyncConfig}   a 'async' configuration value to resolve later with `resolveAsyncConfigs`
+ * @returns {Promise}     a marked promise to be resolve later using `resolveAsyncConfigs`
  */
-function asyncConfig (promiseOrFunc) {
+function asyncConfig(promiseOrFunc) {
   if (typeof promiseOrFunc === 'function') {  // also acts as deferConfig
     return deferConfig(function (config, original) {
-      return asyncConfig(promiseOrFunc.call(config, config, original));
+      var release;
+      function registerRelease(resolve) { release = resolve; }
+      function callFunc() { return promiseOrFunc.call(config, config, original); }
+      var promise = asyncConfig(new Promise(registerRelease).then(callFunc));
+      promise.release = release;
+      return promise;
     });
   }
-  var obj = Object.create(AsyncConfig.prototype);
-  obj.getPromise = function() { return promiseOrFunc; };
-  return obj;
+  var promise = promiseOrFunc;
+  promise.async = asyncSymbol;
+  promise.prepare = function(config, prop, property) {
+    if (promise.release) {
+      promise.release();
+    }
+    return function() {
+      return promise.then(function(value) {
+        Object.defineProperty(prop, property, {value: value});
+      });
+    };
+  };
+  return promise;
 }
 
 /**
@@ -26,6 +39,7 @@ function asyncConfig (promiseOrFunc) {
  */
 function resolveAsyncConfigs(config) {
   var promises = [];
+  var resolvers = [];
   (function iterate(prop) {
     var propsToSort = [];
     for (var property in prop) {
@@ -40,20 +54,17 @@ function resolveAsyncConfigs(config) {
       else if (prop[property].constructor === Array) {
         prop[property].forEach(iterate);
       }
-      else if (prop[property] instanceof AsyncConfig) {
-        promises.push(
-          prop[property].getPromise().then(function(val) { prop[property] = val; }, function(err) {
-            prop[property] = undefined;
-            console.error(err);
-          })
-        );
+      else if (prop[property] && prop[property].async === asyncSymbol) {
+        resolvers.push(prop[property].prepare(config, prop, property));
+        promises.push(prop[property]);
       }
     });
   })(config);
-  return Promise.all(promises).then(function() { return config; });
+  return Promise.all(promises).then(function() {
+    resolvers.forEach(function(resolve) { resolve(); });
+    return config;
+  });
 }
 
 module.exports.asyncConfig = asyncConfig;
-module.exports.AsyncConfig = AsyncConfig;
-
 module.exports.resolveAsyncConfigs = resolveAsyncConfigs;

--- a/lib/config.js
+++ b/lib/config.js
@@ -566,7 +566,7 @@ util.loadFileConfigs = function(configDir) {
   var baseNames = ['default'].concat(NODE_ENV);
 
   // #236: Also add full hostname when they are different.
-  if ( hostName ) {
+  if (hostName) {
     var firstDomain = hostName.split('.')[0];
 
     NODE_ENV.forEach(function(env) {
@@ -574,7 +574,7 @@ util.loadFileConfigs = function(configDir) {
       baseNames.push(firstDomain, firstDomain + '-' + env);
 
       // Add full hostname when it is not the same
-      if ( hostName != firstDomain ) {
+      if (hostName !== firstDomain) {
         baseNames.push(hostName, hostName + '-' + env);
       }
     });
@@ -584,27 +584,24 @@ util.loadFileConfigs = function(configDir) {
     baseNames.push('local', 'local-' + env);
   });
 
-
+  var allowedFiles = {};
+  var resolutionIndex = 1;
   var extNames = Parser.getFilesOrder();
   baseNames.forEach(function(baseName) {
     extNames.forEach(function(extName) {
-
-      // Try merging the config object into this object
-      var fullFilename = Path.join(CONFIG_DIR , baseName + '.' + extName);
-      var configObj = util.parseFile(fullFilename);
-      if (configObj) {
-        util.extendDeep(config, configObj);
-      }
-
-      // See if the application instance file is available
+      allowedFiles[baseName + '.' + extName] = resolutionIndex++;
       if (APP_INSTANCE) {
-        fullFilename = Path.join(CONFIG_DIR, baseName + '-' + APP_INSTANCE + '.' + extName);
-        configObj = util.parseFile(fullFilename);
-        if (configObj) {
-          util.extendDeep(config, configObj);
-        }
+        allowedFiles[baseName + '-' + APP_INSTANCE + '.' + extName] = resolutionIndex++;
       }
     });
+  });
+
+  var locatedFiles = util.locateMatchingFiles(CONFIG_DIR, allowedFiles);
+  locatedFiles.forEach(function(fullFilename) {
+    var configObj = util.parseFile(fullFilename);
+    if (configObj) {
+      util.extendDeep(config, configObj);
+    }
   });
 
   // Override configurations from the $NODE_CONFIG environment variable
@@ -655,6 +652,25 @@ util.loadFileConfigs = function(configDir) {
 
   // Return the configuration object
   return config;
+};
+
+util.locateMatchingFiles = function(configDirs, allowedFiles) {
+  return configDirs.split(':')
+    .reduce(function(files, configDir) {
+      if (configDir) {
+        try {
+          FileSystem.readdirSync(configDir).forEach(function(file) {
+            if (allowedFiles[file]) {
+              files.push([allowedFiles[file], Path.join(configDir, file)]);
+            }
+          });
+        }
+        catch(e) {}
+        return files;
+      }
+    }, [])
+    .sort(function(a, b) { return a[0] - b[0]; })
+    .map(function(file) { return file[1]; });
 };
 
 // Using basic recursion pattern, find all the deferred values and resolve them.
@@ -731,25 +747,16 @@ util.parseFile = function(fullFilename) {
       fileContent = null,
       stat = null;
 
-  // Return null if the file doesn't exist.
   // Note that all methods here are the Sync versions.  This is appropriate during
   // module loading (which is a synchronous operation), but not thereafter.
-  try {
-    stat = FileSystem.statSync(fullFilename);
-    if (!stat || stat.size < 1) {
-      return null;
-    }
-  } catch (e1) {
-    return null
-  }
 
-  // Try loading the file.
   try {
-    fileContent = FileSystem.readFileSync(fullFilename, 'UTF-8');
+    // Try loading the file.
+    fileContent = FileSystem.readFileSync(fullFilename, 'utf-8');
     fileContent = fileContent.replace(/^\uFEFF/, '');
   }
   catch (e2) {
-    throw new Error('Config file ' + fullFilename + ' cannot be read');
+    return null;  // file doesn't exists
   }
 
   // Parse the file based on extension

--- a/lib/config.js
+++ b/lib/config.js
@@ -756,6 +756,9 @@ util.parseFile = function(fullFilename) {
     fileContent = fileContent.replace(/^\uFEFF/, '');
   }
   catch (e2) {
+    if (e2.code !== 'ENOENT') {
+      throw new Error('Config file ' + fullFilename + ' cannot be read');
+    }
     return null;  // file doesn't exists
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -951,6 +951,8 @@ util.cloneDeep = function cloneDeep(parent, depth, circular, prototype) {
 
       if (hasGetter){
         Object.defineProperty(child,i,propDescriptor);
+      } else if (util.isPromise(parent[i])) {
+        child[i] = parent[i];
       } else {
         child[i] = _clone(parent[i], depth - 1);
       }
@@ -1216,9 +1218,11 @@ util.extendDeep = function(mergeInto) {
       } else if (util.isObject(mergeInto[prop]) && util.isObject(mergeFrom[prop]) && !isDeferredFunc) {
         util.extendDeep(mergeInto[prop], mergeFrom[prop], depth - 1);
       }
-
+      else if (util.isPromise(mergeFrom[prop])) {
+        mergeInto[prop] = mergeFrom[prop];
+      }
       // Copy recursively if the mergeFrom element is an object (or array or fn)
-      else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object' && !util.isPromise(mergeFrom[prop])) {
+      else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object') {
         mergeInto[prop] = util.cloneDeep(mergeFrom[prop], depth -1);
       }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -654,6 +654,17 @@ util.loadFileConfigs = function(configDir) {
   return config;
 };
 
+/**
+ * Return a list of fullFilenames who exists in allowedFiles
+ * Ordered according to allowedFiles argument specifications
+ *
+ * @protected
+ * @method locateMatchingFiles
+ * @param configDirs {string}   the config dir, or multiple dirs separated by a column (:)
+ * @param allowedFiles {object} an object. keys and supported filenames
+ *                              and values are the position in the resolution order
+ * @returns {string[]}          fullFilenames - path + filename
+ */
 util.locateMatchingFiles = function(configDirs, allowedFiles) {
   return configDirs.split(':')
     .reduce(function(files, configDir) {

--- a/test/15-async-configs.js
+++ b/test/15-async-configs.js
@@ -61,5 +61,9 @@ vows.describe('Tests for async values - JavaScript').addBatch({
     "second async promise return local value." : function () {
       assert.equal(CONFIG.original.originalPromise, 'not an original value');
     },
+
+    "verify deferred functionality plays nicely with AsyncConfig." : function () {
+      assert.equal(CONFIG.promiseSubject, 'New Instance! Welcome to New Instance!');
+    },
   }
 }).export(module);

--- a/test/15-config/local.js
+++ b/test/15-config/local.js
@@ -1,7 +1,11 @@
 var asyncConfig = require('../../async').asyncConfig;
 
 var config = {
- siteTitle : 'New Instance!',
+  siteTitle : 'New Instance!',
+  promiseSubject: asyncConfig(async function(cfg) {
+    var subject = await cfg.welcomeEmail.subject;
+    return this.siteTitle+' '+subject;
+  })
 };
 
 config.map = {

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -388,4 +388,48 @@ vows.describe('Test suite for node-config')
     }
   },
 })
+  .addBatch({
+    'Library initialization from multiple directories': {
+      topic : function () {
+        // Change the configuration directory for testing
+        process.env.NODE_CONFIG_DIR = __dirname + '/config:' + __dirname + '/x-config';
+
+        // Hardcode $NODE_ENV=test for testing
+        process.env.NODE_ENV='test';
+
+        // Test for multi-instance applications
+        process.env.NODE_APP_INSTANCE='3';
+
+        // Test $NODE_CONFIG environment and --NODE_CONFIG command line parameter
+        process.env.NODE_CONFIG='{"EnvOverride":{"parm3":"overridden from $NODE_CONFIG","parm4":100}}';
+        process.argv.push('--NODE_CONFIG={"EnvOverride":{"parm5":"overridden from --NODE_CONFIG","parm6":101}}');
+
+        // Test Environment Variable Substitution
+        override = 'CUSTOM VALUE FROM JSON ENV MAPPING';
+        process.env.CUSTOM_JSON_ENVIRONMENT_VAR = override;
+
+        CONFIG = requireUncached(__dirname + '/../lib/config');
+
+        return CONFIG;
+
+      },
+      'Config library is available': function() {
+        assert.isObject(CONFIG);
+      },
+      'Config extensions are included with the library': function() {
+        assert.isFunction(CONFIG.util.cloneDeep);
+      }
+    },
+    'Multiple config direcoties': {
+      'Verify first directory loaded': function() {
+        assert.equal(CONFIG.get('Customers.dbName'), 'from_default_xml');
+      },
+      'Verify second directory loaded': function() {
+        assert.equal(CONFIG.get('different.dir'), true);
+      },
+      'Verify correct resolution order': function() {
+        assert.equal(CONFIG.get('AnotherModule.parm4'), 'x_config_4_win');
+      },
+    }
+  })
 .export(module);

--- a/test/x-config/default.xml
+++ b/test/x-config/default.xml
@@ -1,0 +1,5 @@
+<config>
+    <AnotherModule>
+        <parm4>x_config_4_win</parm4>
+    </AnotherModule>
+</config>

--- a/test/x-config/local.yml
+++ b/test/x-config/local.yml
@@ -1,0 +1,2 @@
+different:
+  dir: True


### PR DESCRIPTION
Addresses #560

1. Improved logic to first read directory files and filter those which are relevant to us, then we only try to read them.
2. Allow passing `CONFIG_DIR` with multiple directories separated by `:`. (like PATH)
3. Make sure `NODE_APP_INSTANCE` is loaded on all supported extensions.

Notice that current resolution order won't be separated to each directory but according to files resolution rules. The directory is only used to sort between exact files in separate directories, then the directory index in `CONFIG_DIR` is used to sort.
```
util.locateMatchingFiles('a:b', {'default': 1, 'local': 2})
a/default
b/default
a/local
b/local
```
What do you think  the logic should be in case we add support for multiple directories?

**Edit** I believe the ideal use case would look like that:
```
config/default.js
config/production.json
config/production-instance.json
srv-config/hostname.yaml
srv-config/hostname-instance.yaml
srv-config/hostname-production.yaml
srv-config/hostname-production-instance.yaml
local-config/local.json5
local-config/local-instance.js
```
OR
```
config/default.js
config/production.json
electron-local-config/hostname.yaml
electron-local-config/hostname-production.yaml
config/local.json
```
This feature gives a lot of control to DevOps, and personally I'd be happy to have it supported by this library. It would provide me with much more flexibility to defined my application config distribution.