### PR TITLE
Add ESModule support for compiled JS

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -48,7 +48,16 @@ Parser.xmlParser = function(filename, content) {
 };
 
 Parser.jsParser = function(filename, content) {
-  return require(filename);
+  // Imports config if it is exported via module.exports = ...
+  // See https://github.com/lorenwest/node-config/issues/524
+  var configObject = require(filename);
+
+  // Because of ES6 modules usage, `default` is treated as named export (like any other)
+  // Therefore config is a value of `default` key.
+  if (configObject.default) {
+    return configObject.default
+  }
+  return configObject;
 };
 
 Parser.tsParser = function(filename, content) {


### PR DESCRIPTION
This adds the same support for esmodule default exports to the `js` parsers that exists within the `ts` one already.

This resolves an isssue with compiled Typescript here: #521 
This was the original esmodules fix for the `ts` parser #545 

Another option for the condition would be checking `configObject.__esModule` 