### PR TITLE
Fix #567 - Missing path.delimiter breaks windows absolute paths

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -666,7 +666,7 @@ util.loadFileConfigs = function(configDir) {
  * @returns {string[]}          fullFilenames - path + filename
  */
 util.locateMatchingFiles = function(configDirs, allowedFiles) {
-  return configDirs.split(':')
+  return configDirs.split(Path.delimiter)
     .reduce(function(files, configDir) {
       if (configDir) {
         try {


### PR DESCRIPTION
I didn't add tests because we don't run tests on Windows servers as part of our CI.