### PR TITLE
Fixed issue with getCustomEnvVars method and multiple config dirs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1073,8 +1073,13 @@ util.substituteDeep = function (substitutionMap, variables) {
  */
 util.getCustomEnvVars = function (CONFIG_DIR, extNames) {
   var result = {};
+  var resolutionIndex = 1;
+  var allowedFiles = {};
   extNames.forEach(function (extName) {
-    var fullFilename = Path.join(CONFIG_DIR , 'custom-environment-variables' + '.' + extName);
+    allowedFiles['custom-environment-variables' + '.' + extName] = resolutionIndex++;
+  });
+  var locatedFiles = util.locateMatchingFiles(CONFIG_DIR, allowedFiles);
+  locatedFiles.forEach(function (fullFilename) {
     var configObj = util.parseFile(fullFilename);
     if (configObj) {
       var environmentSubstitutions = util.substituteDeep(configObj, process.env);

--- a/test/5-config/custom-environment-variables.json
+++ b/test/5-config/custom-environment-variables.json
@@ -1,0 +1,3 @@
+{
+  "testValue": "TEST_VALUE"
+}

--- a/test/5-extra-config/custom-environment-variables.json
+++ b/test/5-extra-config/custom-environment-variables.json
@@ -1,0 +1,3 @@
+{
+  "siteName": "SITE_NAME"
+}

--- a/test/5-getConfigSources.js
+++ b/test/5-getConfigSources.js
@@ -9,7 +9,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
   'tests with NODE_CONFIG env set, and --NODE_CONFIG command line flag': {
     topic: function () {
      // Change the configuration directory for testing
-     process.env.NODE_CONFIG_DIR = __dirname + '/5-config';
+     process.env.NODE_CONFIG_DIR = [__dirname + '/5-config', __dirname + '/5-extra-config'].join(Path.delimiter);
 
       delete process.env.NODE_ENV;
       process.env.NODE_CONFIG = '{}';
@@ -21,7 +21,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
     },
 
     'Two files plus NODE_CONFIG in env and as command line args should result in four entries': function(topic) {
-        assert.equal(topic.length,4);
+        assert.equal(topic.length,6);
     },
 
     "The environment variable and command line args are the last two overrides": function (topic) {
@@ -46,7 +46,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
     },
 
     'Two files should result in two entries': function(topic) {
-        assert.equal(topic.length,2);
+        assert.equal(topic.length,3);
     },
 
     "The keys for each object are 'name', 'original', and 'parsed'": function(topic) {
@@ -70,7 +70,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
     },
 
     'Two files should result in two entries': function(topic) {
-        assert.equal(topic.length,2);
+        assert.equal(topic.length,3);
     },
 
     "The keys for each object are 'name', 'original', and 'parsed'": function(topic) {
@@ -93,7 +93,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
     },
 
     'Three files should result in 3 entries': function(topic) {
-        assert.equal(topic.length,3);
+        assert.equal(topic.length,4);
     },
 
     'Second file is named empty': function (topic) {


### PR DESCRIPTION
When working with multiple config dirs, custom-environment-variables files no longer works. 

The `getCustomEnvVars` method tries to create file paths by concatenating `CONFIG_DIR` with optional file names, but `CONFIG_DIR` can be a string with multiple dir paths, separated by `:`.