### PR TITLE
Add support for experimental modules

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -281,8 +281,9 @@ Parser.stripYamlComments = function(fileStr) {
   return fileStr.replace(/^\s*#.*/mg,'').replace(/^\s*[\n|\r]+/mg,'');
 };
 
-var order = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
+var order = ['js', 'cjs', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
 var definitions = {
+  cjs: Parser.jsParser,
   coffee: Parser.coffeeParser,
   cson: Parser.csonParser,
   hjson: Parser.hjsonParser,


### PR DESCRIPTION
ES Modules can be used in Node with the --experimental-modules flag.

However, when using the package.json "type": "module" option, which assumes all files in a package are ES modules, then using node-config fails, as the `require` in the parser is unexpected.

Renaming a non-module js file to .cjs allows the non-import usage. This PR adds support for a .cjs file extension for config files with format and behaviour identical to .js.

I appreciate that module support is experimental, however, it's fairly mature, it seems the API is unlikely to change and this change is backward-compatible.

Without this change node-config isn't really usable from a module-first nodejs approach, which is likely to be the default in future (unless I'm missing something).

(haven't added any tests, as not sure where to and you may not agree to the change anyway)