### PR TITLE
Run ts-node in mode transpile-only

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -55,6 +55,7 @@ Parser.tsParser = function(filename, content) {
   if (!require.extensions['.ts']) {
     require(TS_DEP).register({
       lazy: true,
+      transpileOnly: true,
       compilerOptions: {
         allowJs: true,
       }


### PR DESCRIPTION
By default, ts-node is type checking the imported files, doing so on TypeScript config files creates a requirement to have `@types/config` in `dependencies` (as opposed to `devDependencies`) when `config/defer` (or similar) is imported from one of the configuration files.

To read the configuration values, only `transpile-only` is needed (which is also faster to run).