### PR TITLE
Add Ability to use Hostnames with Local Configuration Files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -583,20 +583,23 @@ util.loadFileConfigs = function(configDir) {
     });
   }
 
+  baseNames.push('local');
   NODE_ENV.forEach(function(env) {
-    baseNames.push('local', 'local-' + env);
+    baseNames.push('local-' + env);
   });
 
 
   if (firstDomain) {
+    baseNames.push('local-' + firstDomain);
     NODE_ENV.forEach(function(env) {
-      baseNames.push('local-' + firstDomain, 'local-' + firstDomain + '-' + env);
+      baseNames.push('local-' + firstDomain + '-' + env);
     });
   }
 
   if (hostName && hostName !== firstDomain) {
+    baseNames.push('local-' + hostName);
     NODE_ENV.forEach(function(env) {
-      baseNames.push('local-' + hostName, 'local-' + hostName + '-' + env);
+      baseNames.push('local-' + hostName + '-' + env);
     });
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -459,6 +459,8 @@ util.getConfigSources = function() {
  *   (hostname)-(deployment).EXT
  *   local.EXT
  *   local-(deployment).EXT
+ *   local-(hostname).EXT
+ *   local-(hostname)-(deployment).EXT
  *   runtime.json
  * </pre>
  *
@@ -566,8 +568,9 @@ util.loadFileConfigs = function(configDir) {
   var baseNames = ['default'].concat(NODE_ENV);
 
   // #236: Also add full hostname when they are different.
+  var firstDomain;
   if (hostName) {
-    var firstDomain = hostName.split('.')[0];
+    firstDomain = hostName.split('.')[0];
 
     NODE_ENV.forEach(function(env) {
       // Backward compatibility
@@ -583,6 +586,19 @@ util.loadFileConfigs = function(configDir) {
   NODE_ENV.forEach(function(env) {
     baseNames.push('local', 'local-' + env);
   });
+
+
+  if (firstDomain) {
+    NODE_ENV.forEach(function(env) {
+      baseNames.push('local-' + firstDomain, 'local-' + firstDomain + '-' + env);
+    });
+  }
+
+  if (hostName && hostName !== firstDomain) {
+    NODE_ENV.forEach(function(env) {
+      baseNames.push('local-' + hostName, 'local-' + hostName + '-' + env);
+    });
+  }
 
   var allowedFiles = {};
   var resolutionIndex = 1;


### PR DESCRIPTION
Hello!

My company found the temporary need to have `local.EXT` configuration files that were augmented by the hostname. I created the work to support this and used it within development, but now no longer need it. However, I figured that the work shouldn't go to waste if it's something you @lorenwest would like to incorporate into the upstream fork.

I could try to squeeze some time to add tests for this, but not sure when I'd be able to get around to that.

We love your library; thank you for saving me and others so much time with this awesome library (we had a haphazard `.env` setup for our large multi-environment monorepo)

Let me know what your thoughts are! Happy to answer any questions. Basically, `local-(hostname).EXT` and `local-(hostname)-(deployment).EXT` are added to the end of the order of superseding config.