### PR TITLE
Ability to parse environment variables as number or boolean

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -199,6 +199,14 @@ Parser.propertiesParser = function(filename, content) {
   return PPARSER.parse(content, { namespaces: true, variables: true, sections: true });
 };
 
+Parser.numberParser = function(filename, content) {
+    return Number(content);
+}
+
+Parser.booleanParser = function(filename, content) {
+    return ('' + content === 'true');
+}
+
 /**
  * Strip all Javascript type comments from the string.
  *
@@ -281,7 +289,7 @@ Parser.stripYamlComments = function(fileStr) {
   return fileStr.replace(/^\s*#.*/mg,'').replace(/^\s*[\n|\r]+/mg,'');
 };
 
-var order = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
+var order = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml', 'number', 'boolean'];
 var definitions = {
   coffee: Parser.coffeeParser,
   cson: Parser.csonParser,
@@ -296,6 +304,8 @@ var definitions = {
   xml: Parser.xmlParser,
   yaml: Parser.yamlParser,
   yml: Parser.yamlParser,
+  number: Parser.numberParser,
+  boolean: Parser.booleanParser
 };
 
 Parser.getParser = function(name) {

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -14,7 +14,7 @@ var vows = require('vows'),
  * @class ConfigTest
  */
 
-var CONFIG, MODULE_CONFIG, override;
+var CONFIG, MODULE_CONFIG, override, overrideBoolean, overrideNumber;
 vows.describe('Test suite for node-config')
 .addBatch({
   'Library initialization': {
@@ -35,6 +35,14 @@ vows.describe('Test suite for node-config')
       // Test Environment Variable Substitution
       override = 'CUSTOM VALUE FROM JSON ENV MAPPING';
       process.env.CUSTOM_JSON_ENVIRONMENT_VAR = override;
+      
+      overrideBoolean = "true";
+      process.env.CUSTOM_JSON_BOOLEAN_ENVIRONMENT_VAR = overrideBoolean;
+      
+      overrideNumber = "2";
+      process.env.CUSTOM_JSON_NUMBER_ENVIRONMENT_VAR = overrideNumber;
+      
+
 
       CONFIG = requireUncached(__dirname + '/../lib/config');
 
@@ -159,7 +167,15 @@ vows.describe('Test suite for node-config')
     // NOT testing absence of `custom-environment-variables.json` because current tests don't mess with the filesystem
     'Configuration can come from an environment variable mapped in custom_environment_variables.json': function () {
       assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.json'), override);
-    }
+    },
+
+    'Configuration loaded via environment variable is mapped as boolean if format specified': function () {
+        assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.types.boolean'), Boolean(overrideBoolean));
+    },
+
+    'Configuration loaded via environment variable is mapped as number if format specified': function () {
+        assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.types.number'), Number(overrideNumber));
+    },
   },
 
  'Assuring a configuration property can be hidden': {

--- a/test/config/custom-environment-variables.json
+++ b/test/config/custom-environment-variables.json
@@ -2,7 +2,17 @@
   // With a comment
   "customEnvironmentVariables": {
     "mappedBy": {
-      "json": "CUSTOM_JSON_ENVIRONMENT_VAR"
+      "json": "CUSTOM_JSON_ENVIRONMENT_VAR",
+      "types": {
+        "boolean": {
+            "__name": "CUSTOM_JSON_BOOLEAN_ENVIRONMENT_VAR",
+            "__format": "boolean"
+        },
+        "number": {
+            "__name": "CUSTOM_JSON_NUMBER_ENVIRONMENT_VAR",
+            "__format": "number"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Related to #589, this pull requests allow to specify a custom variable to be formatted via boolean or number.