### PR TITLE
Support .cjs files as alias for .js

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -281,8 +281,9 @@ Parser.stripYamlComments = function(fileStr) {
   return fileStr.replace(/^\s*#.*/mg,'').replace(/^\s*[\n|\r]+/mg,'');
 };
 
-var order = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
+var order = ['js', 'cjs', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
 var definitions = {
+  cjs: Parser.jsParser,
   coffee: Parser.coffeeParser,
   cson: Parser.csonParser,
   hjson: Parser.hjsonParser,

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -99,6 +99,10 @@ vows.describe('Test suite for node-config')
       assert.equal(CONFIG.AnotherModule.parm9, 'value9');
     },
 
+    'Loading configurations from a CJS file is correct': function() {
+      assert.equal(CONFIG.AnotherModule.parm10, 'value10');
+    },
+
     'Loading configurations from an environment file is correct': function() {
       assert.equal(CONFIG.Customers.dbPort, '5999');
     },

--- a/test/config/default.cjs
+++ b/test/config/default.cjs
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  AnotherModule: {
+    parm10: 'value10',
+  },
+  Customers: {
+    dbName: 'from_default_cjs',
+  },
+};


### PR DESCRIPTION
Hello, I normally use `.js` files for writing my config files. I have been trying to migrate running native ESM, and noticed that breaks the current parser logic.

_Ideally_ I would love to write ESM syntax for configs as well, but considering these files are loaded dynamically __and__ synchronously, that would require some new parser. I'd rather not deal with that for now.

Instead, I'd like to just migrate my config files to `.cjs` and maintain the existing loading pattern.

I could open a bug/feature issue to further discuss this if necessary, but seems pretty straightforward to me.