### PR TITLE
Parse boolean and numeric config passed from environment variables

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -281,7 +281,31 @@ Parser.stripYamlComments = function(fileStr) {
   return fileStr.replace(/^\s*#.*/mg,'').replace(/^\s*[\n|\r]+/mg,'');
 };
 
-var order = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml'];
+/**
+ * Parses the environment variable to the boolean equivalent.
+ * Defaults to false
+ *
+ * @param {String} content - Environment variable value
+ * @return {boolean} - Boolean value fo the passed variable value
+ */
+Parser.booleanParser = function(filename, content) {
+  return content === 'true';
+};
+
+/**
+ * Parses the environment variable to the number equivalent.
+ * Defaults to undefined
+ *
+ * @param {String} content - Environment variable value
+ * @return {Number} - Number value fo the passed variable value
+ */
+Parser.numberParser = function(filename, content) {
+  const numberValue = Number(content);
+  return Number.isNaN(numberValue) ? undefined : numberValue;
+};
+
+var order = ['js', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml',
+  'boolean', 'number'];
 var definitions = {
   coffee: Parser.coffeeParser,
   cson: Parser.csonParser,
@@ -296,6 +320,8 @@ var definitions = {
   xml: Parser.xmlParser,
   yaml: Parser.yamlParser,
   yml: Parser.yamlParser,
+  boolean: Parser.booleanParser,
+  number: Parser.numberParser
 };
 
 Parser.getParser = function(name) {

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -14,7 +14,7 @@ var vows = require('vows'),
  * @class ConfigTest
  */
 
-var CONFIG, MODULE_CONFIG, override;
+var CONFIG, MODULE_CONFIG, override, numberInteger, numberFloat;
 vows.describe('Test suite for node-config')
 .addBatch({
   'Library initialization': {
@@ -35,6 +35,19 @@ vows.describe('Test suite for node-config')
       // Test Environment Variable Substitution
       override = 'CUSTOM VALUE FROM JSON ENV MAPPING';
       process.env.CUSTOM_JSON_ENVIRONMENT_VAR = override;
+
+      // Test Environment variable substitution of boolean values
+      process.env.CUSTOM_BOOLEAN_TRUE_ENVIRONMENT_VAR = 'true';
+      process.env.CUSTOM_BOOLEAN_FALSE_ENVIRONMENT_VAR = 'false';
+      process.env.CUSTOM_BOOLEAN_ERROR_ENVIRONMENT_VAR = 'notProperBoolean';
+
+      // Test Environment variable substitution of numeric values
+      numberInteger = 1001;
+      numberFloat = 3.14
+      process.env.CUSTOM_NUMBER_INTEGER_ENVIRONMENT_VAR = numberInteger;
+      process.env.CUSTOM_NUMBER_FLOAT_ENVIRONMENT_VAR = numberFloat;
+      process.env.CUSTOM_NUMBER_EMPTY_ENVIRONMENT_VAR = '';
+      process.env.CUSTOM_NUMBER_STRING_ENVIRONMENT_VAR = 'String';
 
       CONFIG = requireUncached(__dirname + '/../lib/config');
 
@@ -159,7 +172,37 @@ vows.describe('Test suite for node-config')
     // NOT testing absence of `custom-environment-variables.json` because current tests don't mess with the filesystem
     'Configuration can come from an environment variable mapped in custom_environment_variables.json': function () {
       assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.json'), override);
-    }
+    },
+
+    'Environment variables specified as boolean true': function () {
+      assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.formats.booleanTrue'), true);
+    },
+
+    'Environment variables specified as boolean false': function () {
+      assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.formats.booleanFalse'), false);
+    },
+
+    'Environment variables not specified as a proper boolean value': function () {
+      assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.formats.notProperBoolean'), false);
+    },
+
+    'Environment variables specified as an integer number': function () {
+      assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.formats.numberInteger'), numberInteger);
+    },
+
+    'Environment variables specified as a floating number': function () {
+      assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.formats.numberFloat'), numberFloat);
+    },
+
+    'Environment variables specified as a number but empty string passed': function () {
+      assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.formats.numberEmpty'), 0);
+    },
+
+    'Environment variables specified as a number but alphanumeric string passed': function () {
+      assert.throws(function () { CONFIG.get('customEnvironmentVariables.mappedBy.formats.numberString'); },
+        /Configuration property "customEnvironmentVariables.mappedBy.formats.numberString" is not defined/
+      )
+    },
   },
 
  'Assuring a configuration property can be hidden': {

--- a/test/config/custom-environment-variables.json
+++ b/test/config/custom-environment-variables.json
@@ -2,7 +2,37 @@
   // With a comment
   "customEnvironmentVariables": {
     "mappedBy": {
-      "json": "CUSTOM_JSON_ENVIRONMENT_VAR"
+      "json": "CUSTOM_JSON_ENVIRONMENT_VAR",
+      "formats": {
+        "booleanTrue": {
+          "__name": "CUSTOM_BOOLEAN_TRUE_ENVIRONMENT_VAR",
+          "__format": "boolean"
+        },
+        "booleanFalse": {
+          "__name": "CUSTOM_BOOLEAN_FALSE_ENVIRONMENT_VAR",
+          "__format": "boolean"
+        },
+        "notProperBoolean": {
+          "__name": "CUSTOM_BOOLEAN_ERROR_ENVIRONMENT_VAR",
+          "__format": "boolean"
+        },
+        "numberInteger": {
+          "__name": "CUSTOM_NUMBER_INTEGER_ENVIRONMENT_VAR",
+          "__format": "number"
+        },
+        "numberFloat": {
+          "__name": "CUSTOM_NUMBER_FLOAT_ENVIRONMENT_VAR",
+          "__format": "number"
+        },
+        "numberEmpty": {
+          "__name": "CUSTOM_NUMBER_EMPTY_ENVIRONMENT_VAR",
+          "__format": "number"
+        },
+        "numberString": {
+          "__name": "CUSTOM_NUMBER_STRING_ENVIRONMENT_VAR",
+          "__format": "number"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- Added support to parse boolean and nimeric config values
- Added supporting tests

This PR might resolve Issue: #615, #589 