### PR TITLE
Fix #574: TOML error when using array of tables

### DIFF
--- a/async.js
+++ b/async.js
@@ -43,7 +43,7 @@ function resolveAsyncConfigs(config) {
   (function iterate(prop) {
     var propsToSort = [];
     for (var property in prop) {
-      if (prop.hasOwnProperty(property) && prop[property] != null) {
+      if (Object.hasOwnProperty.call(prop, property) && prop[property] != null) {
         propsToSort.push(property);
       }
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -713,7 +713,7 @@ util.resolveDeferredConfigs = function (config) {
 
     // First step is to put the properties of interest in an array
     for (var property in prop) {
-      if (prop.hasOwnProperty(property) && prop[property] != null) {
+      if (Object.hasOwnProperty.call(prop, property) && prop[property] != null) {
         propsToSort.push(property);
       }
     }
@@ -1023,7 +1023,7 @@ util.setPath = function (object, path, value) {
   }
   else {
     nextKey = path.shift();
-    if (!object.hasOwnProperty(nextKey)) {
+    if (!Object.hasOwnProperty.call(object, nextKey)) {
       object[nextKey] = {};
     }
     util.setPath(object[nextKey], path, value);
@@ -1257,7 +1257,7 @@ util.extendDeep = function(mergeInto) {
       var fromIsDeferredFunc = mergeFrom[prop] instanceof DeferredConfig;
       var isDeferredFunc = mergeInto[prop] instanceof DeferredConfig;
 
-      if (fromIsDeferredFunc && mergeInto.hasOwnProperty(prop)) {
+      if (fromIsDeferredFunc && Object.hasOwnProperty.call(mergeInto, prop)) {
         mergeFrom[prop]._original = isDeferredFunc ? mergeInto[prop]._original : mergeInto[prop];
       }
       // Extend recursively if both elements are objects and target is not really a deferred function

--- a/test/17-config/default.toml
+++ b/test/17-config/default.toml
@@ -1,0 +1,7 @@
+[[messages]]
+field1 = "1"
+field2 = "2"
+
+[[messages]]
+field1 = "a"
+field3 = "3"

--- a/test/17-toml.js
+++ b/test/17-toml.js
@@ -1,0 +1,30 @@
+var requireUncached = require('./_utils/requireUncached');
+var Parser = require('../parser');
+
+'use strict';
+
+var vows = require('vows'),
+  assert = require('assert');
+
+vows.describe('Tests for parsing TOML files')
+  .addBatch({
+    'Using the default parser - Array of Tables': {
+      topic: function() {
+        process.env.NODE_CONFIG_DIR = __dirname + '/17-config';
+        return requireUncached(__dirname + '/../lib/config');
+      },
+      'validate array of tables is supported': function(CONFIG) {
+        assert.deepStrictEqual(CONFIG.get('messages'), [
+          {
+            field1: '1',
+            field2: '2'
+          },
+          {
+            field1: 'a',
+            field3: '3'
+          }
+        ]);
+      },
+    }
+  })
+  .export(module);


### PR DESCRIPTION
The TOML library clears the object prototype which results in foo.hasOwnProperty(bar) failing.
Using Object.hasOwnProperty.call(foo, bar) instead.

Fix #574