### PR TITLE
Fix #593 (Don't treat empty strings as valid values)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1084,12 +1084,12 @@ util.substituteDeep = function (substitutionMap, variables) {
     for (var prop in map) {
       var value = map[prop];
       if (typeof(value) === 'string') { // We found a leaf variable name
-        if (vars[value] !== undefined) { // if the vars provide a value set the value in the result map
+        if (vars[value] !== undefined && vars[value] !== '') { // if the vars provide a value set the value in the result map
           util.setPath(result, pathTo.concat(prop), vars[value]);
         }
       }
       else if (util.isObject(value)) { // work on the subtree, giving it a clone of the pathTo
-        if ('__name' in value && '__format' in value && vars[value.__name] !== undefined) {
+        if ('__name' in value && '__format' in value && vars[value.__name] !== undefined && vars[value.__name] !== '') {
           try {
             var parsedValue = util.parseString(vars[value.__name], value.__format);
           } catch(err) {

--- a/test/1-protected-test.js
+++ b/test/1-protected-test.js
@@ -347,7 +347,6 @@ vows.describe('Protected (hackable) utilities test')
       assert.deepEqual(substituted, {
         TopLevel: 0,
         Customers: {
-          dbName: '',
           oauth: {
             key: 'null',
             secret: 'false'

--- a/test/19-config/custom-environment-variables.json
+++ b/test/19-config/custom-environment-variables.json
@@ -1,0 +1,7 @@
+{
+  "testValue": "TEST_VALUE",
+  "testJSONValue": {
+    "__name": "TEST_JSON_VALUE",
+    "__format": "json"
+  }
+}

--- a/test/19-config/default.js
+++ b/test/19-config/default.js
@@ -1,0 +1,10 @@
+
+var config = {
+  testValue : 'from js',
+  testJSONValue : {
+    fromJS: true,
+    type: 'JSON'
+  },
+};
+
+module.exports = config;

--- a/test/19-custom-environment-variables.js
+++ b/test/19-custom-environment-variables.js
@@ -1,0 +1,73 @@
+var requireUncached = require('./_utils/requireUncached');
+
+// Dependencies
+var vows   = require('vows'),
+    assert = require('assert'),
+    Path   = require('path');
+
+vows.describe('Testing custom environment variable overrides')
+.addBatch({
+    'custom environment variable overrides,': {
+        'with unset environment variables': {
+            topic: function () {
+                delete process.env.TEST_VALUE;
+                delete process.env.TEST_JSON_VALUE;
+
+                // Change the configuration directory for testing
+                process.env.NODE_CONFIG_DIR = [__dirname + '/19-config'].join(Path.delimiter);
+                var config = requireUncached(__dirname + '/../lib/config');
+                return {
+                     config,
+                     configObject: config.util.parseFile(Path.join(__dirname,'/19-config/default.js'))
+                 };
+            },
+            'should not override from the environment variables': function(topic) {
+                assert.strictEqual(topic.config.testValue,topic.configObject.testValue);
+                assert.deepStrictEqual(topic.config.testJSONValue,topic.configObject.testJSONValue);
+            },
+        },
+        'with empty string environment variables': {
+            topic: function () {
+                process.env.TEST_VALUE = '';
+                process.env.TEST_JSON_VALUE = '';
+
+                // Change the configuration directory for testing
+                process.env.NODE_CONFIG_DIR = [__dirname + '/19-config'].join(Path.delimiter);
+                var config = requireUncached(__dirname + '/../lib/config');
+                return {
+                     config,
+                     configObject: config.util.parseFile(Path.join(__dirname,'/19-config/default.js'))
+                 };
+            },
+            'should not override from the environment variables': function(topic) {
+                assert.strictEqual(topic.config.testValue,topic.configObject.testValue);
+                assert.deepStrictEqual(topic.config.testJSONValue,topic.configObject.testJSONValue);
+            },
+        },
+        'with string environment variables': {
+            topic: function () {
+                const testValue = 'from env';
+                const jsonValue = {
+                    fromJS: false,
+                    type: 'stringified JSON'
+                }
+                process.env.TEST_VALUE = testValue;
+                process.env.TEST_JSON_VALUE = JSON.stringify(jsonValue);
+
+                // Change the configuration directory for testing
+                process.env.NODE_CONFIG_DIR = [__dirname + '/19-config'].join(Path.delimiter);
+                var config = requireUncached(__dirname + '/../lib/config');
+                return {
+                     config,
+                     testValue,
+                     jsonValue
+                 };
+            },
+            'should override from the environment variables': function(topic) {
+                assert.strictEqual(topic.config.testValue,topic.testValue);
+                assert.deepStrictEqual(topic.config.testJSONValue,topic.jsonValue);
+            },
+        },
+    },
+})
+.export(module);

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -195,7 +195,9 @@ vows.describe('Test suite for node-config')
     },
 
     'Environment variables specified as a number but empty string passed': function () {
-      assert.equal(CONFIG.get('customEnvironmentVariables.mappedBy.formats.numberEmpty'), 0);
+      assert.throws(function () { CONFIG.get('customEnvironmentVariables.mappedBy.formats.numberEmpty'); },
+        /Configuration property "customEnvironmentVariables.mappedBy.formats.numberEmpty" is not defined/
+      )
     },
 
     'Environment variables specified as a number but alphanumeric string passed': function () {


### PR DESCRIPTION
This is a first-attempt PR to add tests to demonstrate the problem described in #593, and to fix that issue. It keeps the behavior that allows other falsey values, such as numeric `0`, which was a main benefit of the PR (#582) that stopped ignoring empty environment variables.

Note that I had to adjust a couple existing tests that broke due to my fix; I believe the tests were describing behavior that is incompatible with ignoring empty strings, and both tests were added at the same time or after the old behavior was broken in 3.3.0. Please let me know if this is incorrect or undesired.

Also note that I am unfamiliar with the test format that `node-config` uses, so I'd be happy to reformat/reorganize my added tests if there's a better place to put them - just let me know.