### PR TITLE
Fix homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./lib/config.js",
   "description": "Configuration control for production node deployments",
   "author": "Loren West <open_source@lorenwest.com>",
-  "homepage": "http://lorenwest.github.com/node-config",
+  "homepage": "http://lorenwest.github.io/node-config",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
 Subdomains of github.com are deprecated for GitHub Pages and not redirecting anymore to github.io since April 15, 2021.