### PR TITLE
Allow multiple relative directory paths separated by path.delimiter to work

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -563,9 +563,7 @@ util.loadFileConfigs = function(configDir, options) {
   NODE_ENV = NODE_ENV.split(',');
 
   CONFIG_DIR = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
-  if (CONFIG_DIR.indexOf('.') === 0) {
-    CONFIG_DIR = Path.join(process.cwd() , CONFIG_DIR);
-  }
+  CONFIG_DIR = _toAbsolutePath(CONFIG_DIR);
 
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
   HOST = util.initParam('HOST');
@@ -718,6 +716,7 @@ util.locateMatchingFiles = function(configDirs, allowedFiles) {
   return configDirs.split(Path.delimiter)
     .reduce(function(files, configDir) {
       if (configDir) {
+        configDir = _toAbsolutePath(configDir);
         try {
           FileSystem.readdirSync(configDir).forEach(function(file) {
             if (allowedFiles[file]) {
@@ -1487,6 +1486,15 @@ util.runStrictnessChecks = function (config) {
     }
   }
 };
+
+// Helper functions shared accross object members
+function _toAbsolutePath (configDir) {
+  if (configDir.indexOf('.') === 0) {
+    return Path.join(process.cwd(), configDir);
+  }
+
+  return configDir;
+}
 
 // Instantiate and export the configuration
 var config = module.exports = new Config();

--- a/test/20-config/default.js
+++ b/test/20-config/default.js
@@ -1,0 +1,4 @@
+module.exports = {
+  foo: '20-config',
+  baz: '20-config',
+}

--- a/test/20-extra-config/default.js
+++ b/test/20-extra-config/default.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo: '20-extra-config',
+}

--- a/test/20-multiple-config.js
+++ b/test/20-multiple-config.js
@@ -1,0 +1,59 @@
+const vows = require('vows');
+const assert = require('assert');
+const path = require('path');
+const requireUncached = require('./_utils/requireUncached');
+
+vows.describe('Tests for multiple config')
+.addBatch({
+  'Adding multiple relative configuration paths should work without error': function () {
+    process.env.NODE_CONFIG_DIR =  [
+      './test/20-config',
+      './test/20-extra-config',
+    ].join(path.delimiter)
+
+    assert.doesNotThrow(function () {
+      const CONFIG = requireUncached(__dirname + '/../lib/config');
+    }, 'Adding multiple relative configuration paths has an error');
+
+  }
+})
+.addBatch({
+  'Adding multiple absolute configuration paths should work without error': function () {
+    process.env.NODE_CONFIG_DIR =  [
+      __dirname + '/20-config',
+      __dirname + '/20-extra-config',
+    ].join(path.delimiter)
+
+    assert.doesNotThrow(function () {
+      const CONFIG = requireUncached(__dirname + '/../lib/config');
+    }, 'Adding multiple absolute configuration paths has an error');
+
+  }
+})
+.addBatch({
+  'Adding one absolute and one relative configuration paths should work without error': function () {
+    process.env.NODE_CONFIG_DIR =  [
+      __dirname + '/20-config',
+      './test/20-extra-config',
+    ].join(path.delimiter)
+
+    assert.doesNotThrow(function () {
+      const CONFIG = requireUncached(__dirname + '/../lib/config');
+    }, 'Adding one absolute and one relative configuration paths has an error');
+
+  }
+})
+.addBatch({
+  'Adding one relative and one absolute configuration paths should work without error': function () {
+    process.env.NODE_CONFIG_DIR =  [
+      './test/20-config',
+      __dirname + '/20-extra-config',
+    ].join(path.delimiter)
+
+    assert.doesNotThrow(function () {
+      const CONFIG = requireUncached(__dirname + '/../lib/config');
+    }, 'Adding one relative and one absolute configuration paths has an error');
+
+  }
+})
+.export(module);


### PR DESCRIPTION
- Add tests for the multiple configurations feature
- transform each relative config dir to an absolute path

fix: https://github.com/lorenwest/node-config/issues/660