### PR TITLE
fix: Parser.jsParser fix

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -562,10 +562,7 @@ util.loadFileConfigs = function(configDir, options) {
   // Split files name, for loading multiple files.
   NODE_ENV = NODE_ENV.split(',');
 
-  CONFIG_DIR = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
-  if (CONFIG_DIR.indexOf('.') === 0) {
-    CONFIG_DIR = Path.join(process.cwd() , CONFIG_DIR);
-  }
+  CONFIG_DIR = Path.resolve( process.cwd(), configDir || util.initParam('NODE_CONFIG_DIR', 'config') );
 
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
   HOST = util.initParam('HOST');

--- a/test/20-config/custom-environment-variables.js
+++ b/test/20-config/custom-environment-variables.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "testValue": "TEST_VALUE",
+  "testJSONValue": {
+    "__name": "TEST_JSON_VALUE",
+    "__format": "json"
+  }
+}

--- a/test/20-config/default.js
+++ b/test/20-config/default.js
@@ -1,0 +1,10 @@
+
+var config = {
+  testValue : 'from js',
+  testJSONValue : {
+    fromJS: true,
+    type: 'JSON'
+  },
+};
+
+module.exports = config;

--- a/test/20-custom-environment-variables.js
+++ b/test/20-custom-environment-variables.js
@@ -1,0 +1,73 @@
+var requireUncached = require('./_utils/requireUncached');
+
+// Dependencies
+var vows   = require('vows'),
+    assert = require('assert'),
+    Path   = require('path');
+
+vows.describe('Testing custom environment variable with relative NODE_CONFIG_DIR and loading js through require')
+.addBatch({
+    'custom environment variable overrides,': {
+        'with unset environment variables': {
+            topic: function () {
+                delete process.env.TEST_VALUE;
+                delete process.env.TEST_JSON_VALUE;
+
+                // Change the configuration directory for testing
+                process.env.NODE_CONFIG_DIR = 'test/20-config';
+                var config = requireUncached(__dirname + '/../lib/config');
+                return {
+                     config,
+                     configObject: config.util.parseFile(Path.join(__dirname,'/20-config/default.js'))
+                 };
+            },
+            'should not override from the environment variables': function(topic) {
+                assert.strictEqual(topic.config.testValue,topic.configObject.testValue);
+                assert.deepStrictEqual(topic.config.testJSONValue,topic.configObject.testJSONValue);
+            },
+        },
+        'with empty string environment variables': {
+            topic: function () {
+                process.env.TEST_VALUE = '';
+                process.env.TEST_JSON_VALUE = '';
+
+                // Change the configuration directory for testing
+                process.env.NODE_CONFIG_DIR = 'test/20-config';
+                var config = requireUncached(__dirname + '/../lib/config');
+                return {
+                     config,
+                     configObject: config.util.parseFile(Path.join(__dirname,'/20-config/default.js'))
+                 };
+            },
+            'should not override from the environment variables': function(topic) {
+                assert.strictEqual(topic.config.testValue,topic.configObject.testValue);
+                assert.deepStrictEqual(topic.config.testJSONValue,topic.configObject.testJSONValue);
+            },
+        },
+        'with string environment variables': {
+            topic: function () {
+                const testValue = 'from env';
+                const jsonValue = {
+                    fromJS: false,
+                    type: 'stringified JSON'
+                }
+                process.env.TEST_VALUE = testValue;
+                process.env.TEST_JSON_VALUE = JSON.stringify(jsonValue);
+
+                // Change the configuration directory for testing
+                process.env.NODE_CONFIG_DIR = 'test/20-config';
+                var config = requireUncached(__dirname + '/../lib/config');
+                return {
+                     config,
+                     testValue,
+                     jsonValue
+                 };
+            },
+            'should override from the environment variables': function(topic) {
+                assert.strictEqual(topic.config.testValue,topic.testValue);
+                assert.deepStrictEqual(topic.config.testJSONValue,topic.jsonValue);
+            },
+        },
+    },
+})
+.export(module);


### PR DESCRIPTION
fix for case when NODE_CONFIG_DIR="environment" - relative path without dots.

It's still valid relative path and it should be supported. 

It was working for a while in our project until we have introduced environment/custom-environment-variables.js then Parser.jsParser was confused calling internally require('environment/custom-environment-variables.js')

if NODE_CONFIG_DIR will be specified as relative path (without dots) then Parser.jsParser might encounter paths like 'environment/custom-environment-variables.js' and loading such path directly to require('environment/custom-environment-variables.js') will be interpreted as loading file 'custom-environment-variables.js' from 'environment' library.. which in most case might not be what you want.