### PR TITLE
Cleanup of file scoped environment variables

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,7 @@ var DeferredConfig = require('../defer').DeferredConfig,
 // Static members
 var DEFAULT_CLONE_DEPTH = 20,
     CONFIG_DIR, RUNTIME_JSON_FILENAME, NODE_ENV, APP_INSTANCE,
-    HOST, HOSTNAME, CONFIG_SKIP_GITCRYPT, NODE_ENV_VAR_NAME,
+    CONFIG_SKIP_GITCRYPT, NODE_ENV_VAR_NAME,
     NODE_CONFIG_PARSER,
     env = {},
     configSources = [],          // Configuration sources - array of {name, original, parsed}
@@ -565,8 +565,6 @@ util.loadFileConfigs = function(configDir, options) {
   }
 
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
-  HOST = util.initParam('HOST');
-  HOSTNAME = util.initParam('HOSTNAME');
   CONFIG_SKIP_GITCRYPT = util.initParam('CONFIG_SKIP_GITCRYPT');
 
   // This is for backward compatibility
@@ -585,6 +583,9 @@ util.loadFileConfigs = function(configDir, options) {
       console.log(e);
     }
   }
+
+  var HOST = util.initParam('HOST');
+  var HOSTNAME = util.initParam('HOSTNAME');
 
   // Determine the host name from the OS module, $HOST, or $HOSTNAME
   // Remove any . appendages, and default to null if not set

--- a/lib/config.js
+++ b/lib/config.js
@@ -1116,18 +1116,18 @@ util.substituteDeep = function (substitutionMap, variables) {
  *
  * @protected
  * @method getCustomEnvVars
- * @param CONFIG_DIR {string} - the passed configuration directory
+ * @param configDir {string} - the passed configuration directory
  * @param extNames {Array[string]} - acceptable configuration file extension names.
  * @returns {object} - mapped environment variables or {} if there are none
  */
-util.getCustomEnvVars = function (CONFIG_DIR, extNames) {
+util.getCustomEnvVars = function (configDir, extNames) {
   var result = {};
   var resolutionIndex = 1;
   var allowedFiles = {};
   extNames.forEach(function (extName) {
     allowedFiles['custom-environment-variables' + '.' + extName] = resolutionIndex++;
   });
-  var locatedFiles = util.locateMatchingFiles(CONFIG_DIR, allowedFiles);
+  var locatedFiles = util.locateMatchingFiles(configDir, allowedFiles);
   locatedFiles.forEach(function (fullFilename) {
     var configObj = util.parseFile(fullFilename);
     if (configObj) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,8 +4,7 @@
 // http://lorenwest.github.com/node-config
 
 // Dependencies
-var deferConfig = require('../defer').deferConfig,
-    DeferredConfig = require('../defer').DeferredConfig,
+var DeferredConfig = require('../defer').DeferredConfig,
     RawConfig = require('../raw').RawConfig,
     Parser = require('../parser'),
     Utils = require('util'),
@@ -14,12 +13,10 @@ var deferConfig = require('../defer').deferConfig,
 
 // Static members
 var DEFAULT_CLONE_DEPTH = 20,
-    NODE_CONFIG, CONFIG_DIR, RUNTIME_JSON_FILENAME, NODE_ENV, APP_INSTANCE,
-    HOST, HOSTNAME, ALLOW_CONFIG_MUTATIONS, CONFIG_SKIP_GITCRYPT, NODE_ENV_VAR_NAME,
+    CONFIG_DIR, RUNTIME_JSON_FILENAME, NODE_ENV, APP_INSTANCE,
+    HOST, HOSTNAME, CONFIG_SKIP_GITCRYPT, NODE_ENV_VAR_NAME,
     NODE_CONFIG_PARSER,
     env = {},
-    privateUtil = {},
-    deprecationWarnings = {},
     configSources = [],          // Configuration sources - array of {name, original, parsed}
     checkMutability = true,      // Check for mutability/immutability on first get
     gitCryptTestRegex = /^.GITCRYPT/; // regular expression to test for gitcrypt files.


### PR DESCRIPTION
This change removes all of the unused variables and fixes one case of variable shadowing.

I am slowly working toward separating config.util into its own file, but there are a number of couplings between it and the parent scope that will need to be sorted out.

