### PR TITLE
Reentrancy bugs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,7 @@ var DeferredConfig = require('../defer').DeferredConfig,
 
 // Static members
 var DEFAULT_CLONE_DEPTH = 20,
-    CONFIG_DIR, RUNTIME_JSON_FILENAME, NODE_ENV, APP_INSTANCE,
+    CONFIG_DIR, NODE_ENV, APP_INSTANCE,
     CONFIG_SKIP_GITCRYPT, NODE_ENV_VAR_NAME,
     NODE_CONFIG_PARSER,
     env = {},
@@ -559,21 +559,21 @@ util.loadFileConfigs = function(configDir, options) {
   // Split files name, for loading multiple files.
   NODE_ENV = NODE_ENV.split(',');
 
-  CONFIG_DIR = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
-  CONFIG_DIR = _toAbsolutePath(CONFIG_DIR);
+  var dir = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
+  dir = _toAbsolutePath(dir);
 
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
   CONFIG_SKIP_GITCRYPT = util.initParam('CONFIG_SKIP_GITCRYPT');
 
   // This is for backward compatibility
-  RUNTIME_JSON_FILENAME = util.initParam('NODE_CONFIG_RUNTIME_JSON', Path.join(CONFIG_DIR , 'runtime.json') );
+  var runtimeFilename = util.initParam('NODE_CONFIG_RUNTIME_JSON', Path.join(dir , 'runtime.json') );
 
   NODE_CONFIG_PARSER = util.initParam('NODE_CONFIG_PARSER');
   if (NODE_CONFIG_PARSER) {
     try {
       var parserModule = Path.isAbsolute(NODE_CONFIG_PARSER)
         ? NODE_CONFIG_PARSER
-        : Path.join(CONFIG_DIR, NODE_CONFIG_PARSER);
+        : Path.join(dir, NODE_CONFIG_PARSER);
       Parser = require(parserModule);
     }
     catch (e) {
@@ -635,7 +635,7 @@ util.loadFileConfigs = function(configDir, options) {
     });
   });
 
-  var locatedFiles = util.locateMatchingFiles(CONFIG_DIR, allowedFiles);
+  var locatedFiles = util.locateMatchingFiles(dir, allowedFiles);
   locatedFiles.forEach(function(fullFilename) {
     var configObj = util.parseFile(fullFilename, options);
     if (configObj) {
@@ -647,6 +647,9 @@ util.loadFileConfigs = function(configDir, options) {
   // NODE_CONFIG only applies to the base config
   if (!configDir) {
     var envConfig = {};
+
+    CONFIG_DIR = dir;
+
     if (process.env.NODE_CONFIG) {
       try {
         envConfig = JSON.parse(process.env.NODE_CONFIG);
@@ -686,11 +689,11 @@ util.loadFileConfigs = function(configDir, options) {
   }
 
   // Override with environment variables if there is a custom-environment-variables.EXT mapping file
-  var customEnvVars = util.getCustomEnvVars(CONFIG_DIR, extNames);
+  var customEnvVars = util.getCustomEnvVars(dir, extNames);
   util.extendDeep(config, customEnvVars);
 
   // Extend the original config with the contents of runtime.json (backwards compatibility)
-  var runtimeJson = util.parseFile(RUNTIME_JSON_FILENAME) || {};
+  var runtimeJson = util.parseFile(runtimeFilename) || {};
   util.extendDeep(config, runtimeJson);
 
   util.resolveDeferredConfigs(config);

--- a/test/21-reentrant/default.js
+++ b/test/21-reentrant/default.js
@@ -1,0 +1,8 @@
+var util = require('../../lib/config').util;
+
+var config = {
+  testValue : 'from js',
+  nested: util.loadFileConfigs(__dirname +  "/nested")
+};
+
+module.exports = config;

--- a/test/21-reentrant/nested/default.js
+++ b/test/21-reentrant/nested/default.js
@@ -1,0 +1,3 @@
+module.exports = {
+  loaded: true
+};

--- a/test/21-reentrant/runtime.json
+++ b/test/21-reentrant/runtime.json
@@ -1,0 +1,3 @@
+{
+  "runtime": true
+}

--- a/test/util.js
+++ b/test/util.js
@@ -1,13 +1,14 @@
+var requireUncached = require('./_utils/requireUncached');
 
 // Tests for config.util functions
+
 
 // Dependencies
 var vows = require('vows'),
     assert = require('assert'),
     path = require('path'),
     config = require('../lib/config'),
-    initParam = config.util.initParam,
-    loadFileConfigs = config.util.loadFileConfigs;
+    initParam = config.util.initParam;
 
 vows.describe('Tests for config util functions')
 .addBatch({
@@ -39,17 +40,27 @@ vows.describe('Tests for config util functions')
         },
     },
     'Tests for util.loadFileConfigs': {
-        'It can load data from a given directory': function () {
-          var result = loadFileConfigs(path.join(__dirname, '5-config'));
+        topic: function () {
+            // Change the configuration directory for testing
+            process.env.NODE_CONFIG_DIR = __dirname + '/config';
+
+            // Hard-code $NODE_CONFIG_ENV=test for testing
+            delete process.env.NODE_APP_INSTANCE;
+            process.env.NODE_CONFIG_ENV='test';
+
+            return requireUncached(__dirname + '/../lib/config').util;
+        },
+        'It can load data from a given directory': function (util) {
+          var result = util.loadFileConfigs(path.join(__dirname, '5-config'));
           assert.strictEqual(result.number, 5);
         },
-        'It ignores NODE_CONFIG when loading from directory': function () {
+        'It ignores NODE_CONFIG when loading from directory': function (util) {
           var prev = process.env.NODE_CONFIG;
-          process.env.NODE_CONFIG = '{"number":4}'
-          var result = loadFileConfigs(path.join(__dirname, '5-config'));
+          process.env.NODE_CONFIG = '{"number":4}';
+          var result = util.loadFileConfigs(path.join(__dirname, '5-config'));
           assert.strictEqual(result.number, 5);
           process.env.NODE_CONFIG = prev;
-        },
+        }
     },
     'Tests for util.isPromise': {
       'It can identify a new Promise': function () {

--- a/test/util.js
+++ b/test/util.js
@@ -60,6 +60,11 @@ vows.describe('Tests for config util functions')
           var result = util.loadFileConfigs(path.join(__dirname, '5-config'));
           assert.strictEqual(result.number, 5);
           process.env.NODE_CONFIG = prev;
+        },
+        'It can handle recursion': function(util) {
+          var result = util.loadFileConfigs(path.join(__dirname, '21-reentrant'));
+          assert.ok(result.nested, "did not load nested values");
+          assert.ok(result.runtime, "lost track of original CONFIG_DIR before loading runtime.json");
         }
     },
     'Tests for util.isPromise': {


### PR DESCRIPTION
Multiple or nested calls to loadFileConfigs can result in file-scoped variables in lib/config.js being overwritten before being used.

CONFIG_DIR is especially problematic, but I also fixed runtime.json support because it represents the last use of CONFIG_DIR, after parseFiles() has been called.