### PR TITLE
Improved submodule support

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,8 @@ var DEFAULT_CLONE_DEPTH = 20,
     env = {},
     configSources = [],          // Configuration sources - array of {name, original, parsed}
     checkMutability = true,      // Check for mutability/immutability on first get
-    gitCryptTestRegex = /^.GITCRYPT/; // regular expression to test for gitcrypt files.
+    gitCryptTestRegex = /^.GITCRYPT/, // regular expression to test for gitcrypt files.
+    moduleConfigs = {}; // Storage for submodule configs
 
 /**
  * <p>Application Configurations</p>
@@ -172,7 +173,17 @@ Config.prototype.get = function(property) {
     checkMutability = false;
   }
   var t = this,
-      value = getImpl(t, property);
+      value = getImpl(t, property),
+      tmpValue;
+
+  // If value is an object it may be only partial, check to see if the 
+  // full object is in dynamicallyImportedModules
+  if (value === undefined || util.isObject(value)) {
+    tmpValue = getImpl(moduleConfigs, property);
+    if (tmpValue !== undefined) {
+      value = tmpValue;
+    }
+  }
 
   // Produce an exception if the property doesn't exist
   if (value === undefined) {
@@ -203,7 +214,13 @@ Config.prototype.has = function(property) {
     return false;
   }
   var t = this;
-  return (getImpl(t, property) !== undefined);
+  var value = getImpl(t, property);
+
+  // If the value is undefined, check to see if it was dynamically loaded later
+  if (value === undefined) {
+    return (getImpl(moduleConfigs, property) !== undefined);
+  }
+  return (value !== undefined);
 };
 
 /**
@@ -226,7 +243,6 @@ Config.prototype.has = function(property) {
  *   });
  * <br>
  *   // Template name may be overridden by application config files
- *   console.log("Template: " + CONFIG.MyModule.templateName);
  * </pre>
  *
  * <p>
@@ -240,6 +256,12 @@ Config.prototype.has = function(property) {
  * @return moduleConfig {object} - The module level configuration object.
  */
 util.setModuleDefaults = function (moduleName, defaultProperties) {
+ 
+  // Throw error if submodule defaults has already been registered
+  var localModuleConfig = getImpl(moduleConfigs, moduleName);
+  if (localModuleConfig !== undefined) {
+    throw new Error('Submodule "' + moduleName + '" has already been set');
+  }
 
   // Copy the properties into a new object
   var t = this,
@@ -255,25 +277,85 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   util.setPath(configSources[0].parsed, moduleName.split('.'), {});
   util.extendDeep(getImpl(configSources[0].parsed, moduleName), defaultProperties);
 
-  // Create a top level config for this module if it doesn't exist
-  util.setPath(t, moduleName.split('.'), getImpl(t, moduleName) || {});
+  // override default properties with local overrides
+  util.extendDeep(moduleConfig, util.cloneDeep(getImpl(t, moduleName)) || {});
 
-  // Extend local configurations into the module config
-  util.extendDeep(moduleConfig, getImpl(t, moduleName));
-
-  // Merge the extended configs without replacing the original
-  util.extendDeep(getImpl(t, moduleName), moduleConfig);
-
-  // reset the mutability check for "config.get" method.
-  // we are not making t[moduleName] immutable immediately,
-  // since there might be more modifications before the first config.get
-  if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-    checkMutability = true;
-  }
+  // Create a module entry populated with defaults and overrides
+  util.setPath(moduleConfigs, moduleName.split('.'), moduleConfig || {});
 
   // Attach handlers & watchers onto the module config object
-  return util.attachProtoDeep(getImpl(t, moduleName));
+  util.attachProtoDeep(getImpl(moduleConfigs, moduleName));
+
+  // Make the settings for this module immutable
+  if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
+    util.makeImmutable(moduleConfigs, moduleName.split('.').shift());
+  }
+
+  return getImpl(moduleConfigs, moduleName);
 };
+
+
+/**
+ * <p>
+ * Retrieve registered properties for your node.js module with overrides
+ * applied.
+ * </p>
+ *
+ * <p>
+ * This allows module developers to account for multiple instances of their
+ * module by generating configurations at will.  The returned moduleConfig
+ * object will have the same lifecycle as the node module instance.
+ * </p>
+ *
+ * <p>Using the function within your module:</p>
+ * <pre>
+ *   var CONFIG = require("config");
+ *   CONFIG.util.setModuleDefaults("MyModule", {
+ *   &nbsp;&nbsp;templateName: "t-50",
+ *   &nbsp;&nbsp;colorScheme: "green"
+ *   });
+ * <br>
+ *   function MyModuleConstructor(options) {
+ *     this.moduleConfig = config.getModuleConfig("MyModule", options);
+ *   }
+ * <br>
+ *   MyModuleConstructor.prototype.getColorScheme = function() {
+ *     return this.moduleConfig.get('colorScheme');
+ *   }
+ * <br>
+ *   module.exports = MyModuleConstructor;
+ * <br>
+ *   // Template name may be overridden by application config files
+ * </pre>
+ *
+ * <p>
+ * The above example results in a "MyModule" element of the configuration
+ * object, containing an object with the specified default values.
+ * </p>
+ *
+ * @method getModuleConfig
+ * @param moduleName {string} - Name of your module.
+ * @param [overrideProperties] {object} - The properties to override the default options.
+ * @return moduleConfig {object} - The module level configuration object with overrides applied.
+ */
+util.getModuleConfig = function(moduleName, overrideProperties) {
+  // Throw error if submodule defaults has already been registered
+  var moduleConfig,
+    localModuleConfig = getImpl(moduleConfigs, moduleName);
+
+  if (localModuleConfig === undefined) {
+    throw new Error('Submodule "' + moduleName + '" defaults has not been set');
+  }
+
+  moduleConfig = util.extendDeep(util.cloneDeep(localModuleConfig), util.cloneDeep(overrideProperties || {}));
+  util.attachProtoDeep(moduleConfig);
+
+  if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
+    util.makeImmutable(moduleConfig);
+  }
+
+  return moduleConfig;
+}
 
 /**
  * <p>Make a configuration property hidden so it doesn't appear when enumerating
@@ -1311,7 +1393,7 @@ util.extendDeep = function(mergeInto) {
 
       // Copy property descriptor otherwise, preserving accessors
       else if (Object.getOwnPropertyDescriptor(Object(mergeFrom), prop)){
-          Object.defineProperty(mergeInto, prop, Object.getOwnPropertyDescriptor(Object(mergeFrom), prop));
+        Object.defineProperty(mergeInto, prop, Object.getOwnPropertyDescriptor(Object(mergeFrom), prop));
       } else {
           mergeInto[prop] = mergeFrom[prop];
       }

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -388,14 +388,14 @@ vows.describe('Test suite for node-config')
     },
 
     'The module config is in the CONFIG object': function(moduleConfig) {
-      assert.isObject(MODULE_CONFIG.TestModule);
-      assert.deepEqual(MODULE_CONFIG.TestModule, moduleConfig);
+      assert.isObject(MODULE_CONFIG.get('TestModule'));
+      assert.deepEqual(MODULE_CONFIG.get('TestModule'), moduleConfig);
     },
 
     // Regression test for https://github.com/lorenwest/node-config/issues/518
     'The module config did not extend itself with its own name': function(moduleConfig) {
       assert.isFalse('TestModule' in moduleConfig);
-      assert.isFalse('TestModule' in MODULE_CONFIG.TestModule);
+      assert.isFalse('TestModule' in MODULE_CONFIG.get('TestModule'));
     },
 
     'Local configurations are mixed in': function(moduleConfig) {

--- a/test/21-dynamic-module-import.js
+++ b/test/21-dynamic-module-import.js
@@ -1,0 +1,163 @@
+var requireUncached = require('./_utils/requireUncached');
+
+// Dependencies
+var vows = require('vows'),
+    assert = require('assert'),
+    FileSystem = require('fs');
+
+/**
+ * <p>Unit tests for the node-config library.  To run type:</p>
+ * <pre>npm test</pre>
+ * <p>Or, in a project that uses node-config:</p>
+ * <pre>npm test config</pre>
+ *
+ * @class ConfigTest
+ */
+
+var config;
+vows.describe('Dynamically module import test')
+.addBatch({
+  'Library initialization': {
+    topic : function () {
+      // Change the configuration directory for testing
+      process.env.NODE_CONFIG_DIR = __dirname + '/22-dynamic-modules';
+
+      // Hard-code $NODE_ENV=test for testing
+      process.env.NODE_ENV='development';
+
+      config = requireUncached(__dirname + '/../lib/config');
+
+      return config;
+
+    },
+    'Config library is available': function() {
+      assert.isObject(config);
+    },
+    'Config settings for Stooge is available': function() {
+      assert.deepEqual(config.Stooge, {
+        smart: true
+      });
+    },
+    'Make configs immutable': function() {
+      assert.deepEqual(config.util.cloneDeep(config.get('Stooge')), {
+        smart: true
+      });
+    }
+  },
+})
+.addBatch({
+  'Load Stooge Library Dynamically': {
+    topic : function () {
+      // Dynamically load the Stooge module
+      return require(__dirname + '/22-dynamic-modules/Stooge.js')
+    },
+    'Config override settings for Stooge match': function(Stooge) {
+      assert.deepEqual(config.Stooge, {
+        smart: true
+      });
+    },
+    'Config module defaults for Stooge are overridden': function(Stooge) {
+      assert.deepEqual(config.util.cloneDeep(config.get('Stooge')), {
+        bald: false,
+        happy: true,
+        smart: true,
+        canPlayViolin: false
+      });
+    },
+    'Create Moe with overrides and verify his settings': function(Stooge) {
+      var moe = new Stooge({
+        happy: false
+      });
+      assert.deepEqual(config.util.cloneDeep(moe.moduleConfig), {
+        bald: false,
+        happy: false,
+        smart: true,
+        canPlayViolin: false
+      });
+      assert.equal(moe.isBald(), false);
+      assert.equal(moe.isHappy(), false);
+      assert.equal(moe.isSmart(), true);
+      assert.throws(function () {
+        moe.playViolin();
+      }, {
+        name: "Error",
+        message: "I'm a victim of soikemstance!"
+      });
+    },
+    'Create Larry with overrides and verify his settings': function(Stooge) {
+      var larry = new Stooge({
+        happy: true,
+        smart: false,
+        canPlayViolin: true
+      });
+      assert.deepEqual(config.util.cloneDeep(larry.moduleConfig), {
+        bald: false,
+        happy: true,
+        smart: false,
+        canPlayViolin: true
+      });
+      assert.equal(larry.isBald(), false);
+      assert.equal(larry.isHappy(), true);
+      assert.equal(larry.isSmart(), false);
+      assert.equal(larry.playViolin(), true);
+    },
+    'Create Curly with overrides and verify his settings': function(Stooge) {
+      var curly = new Stooge({
+        bald: true,
+        happy: true,
+        smart: false
+      });
+      assert.deepEqual(config.util.cloneDeep(curly.moduleConfig), {
+        bald: true,
+        happy: true,
+        smart: false,
+        canPlayViolin: false
+      });
+      assert.equal(curly.isBald(), true);
+      assert.equal(curly.isHappy(), true);
+      assert.equal(curly.isSmart(), false);
+      assert.throws(function () {
+        curly.playViolin();
+      }, {
+        name: "Error",
+        message: "I'm a victim of soikemstance!"
+      });
+    },
+    'Config module defaults for Stooge haven\'t changed with each module instantiation': function(Stooge) {
+      assert.deepEqual(config.util.cloneDeep(config.get('Stooge')), {
+        bald: false,
+        happy: true,
+        smart: true,
+        canPlayViolin: false
+      });
+    },
+  }
+})
+.addBatch({
+  'Load TestModule Library Dynamically': {
+    topic : function () {
+      // Dynamically load the TestModule module
+      return require(__dirname + '/22-dynamic-modules/TestModule.js')
+    },
+    'Config override settings for TestModule match': function(TestModule) {
+      assert.isUndefined(config.TestModule);
+    },
+    'Config module defaults for TestModule are overridden': function(TestModule) {
+      assert.deepEqual(config.util.cloneDeep(config.get('TestModule')), {
+        test: true,
+        example: true
+      });
+    },
+    'Create Moe with overrides and verify his settings': function(TestModule) {
+      var testModule = new TestModule({
+        happy: false
+      });
+      assert.deepEqual(config.util.cloneDeep(testModule.moduleConfig), {
+        happy: false,
+        test: true,
+        example: true
+      });
+    }
+  }
+})
+.export(module);

--- a/test/22-dynamic-modules/Stooge.js
+++ b/test/22-dynamic-modules/Stooge.js
@@ -1,0 +1,61 @@
+var config = require('../../lib/config');
+
+// Set the module defaults
+config.util.setModuleDefaults('Stooge', {
+  bald: false,
+  happy: true,
+  smart: false,
+  canPlayViolin: false
+});
+
+/**
+ * Create a stooge as you see fit
+ * 
+ * @param options {object}
+ */
+function Stooge(options) {
+  // Get a unique module config based on your defaults with optional override
+  this.moduleConfig = config.util.getModuleConfig('Stooge', options);
+}
+
+/**
+ * Whether the Stooge is smart or not
+ * 
+ * @returns {boolean}
+ */
+Stooge.prototype.isSmart = function() {
+  return this.moduleConfig.get('smart');
+}
+
+/**
+ * Whether the Stooge is happy or not
+ * 
+ * @returns {boolean}
+ */
+Stooge.prototype.isHappy = function() {
+  return this.moduleConfig.get('happy');
+}
+
+/**
+ * Whether the Stooge is bald or not
+ * 
+ * @returns {boolean}
+ */
+Stooge.prototype.isBald = function() {
+  return this.moduleConfig.get('bald');
+}
+
+/**
+ * Plays the violin
+ * 
+ * @throws Will throw an error if the Stooge can't play
+ * @returns {boolean} Whether the violin was played or not
+ */
+Stooge.prototype.playViolin = function() {
+  if (!this.moduleConfig.get('canPlayViolin')) {
+    throw new Error("I'm a victim of soikemstance!")
+  }
+  return true;
+}
+
+module.exports = Stooge;

--- a/test/22-dynamic-modules/TestModule.js
+++ b/test/22-dynamic-modules/TestModule.js
@@ -1,0 +1,19 @@
+var config = require('../../lib/config');
+
+// Set the module defaults
+config.util.setModuleDefaults('TestModule', {
+  test: true,
+  example: true
+});
+
+/**
+ * Create a stooge as you see fit
+ * 
+ * @param options {object}
+ */
+function TestModule(options) {
+  // Get a unique module config based on your defaults with optional override
+  this.moduleConfig = config.util.getModuleConfig('TestModule', options);
+}
+
+module.exports = TestModule;

--- a/test/22-dynamic-modules/default.yaml
+++ b/test/22-dynamic-modules/default.yaml
@@ -1,0 +1,4 @@
+# Example of the baseline configuration in YAML
+
+Stooge:
+  smart: true

--- a/test/22-get-module-config.js
+++ b/test/22-get-module-config.js
@@ -1,0 +1,166 @@
+var requireUncached = require('./_utils/requireUncached');
+
+// Dependencies
+var vows = require('vows'),
+    assert = require('assert'),
+    FileSystem = require('fs');
+
+/**
+ * <p>Unit tests for the node-config library.  To run type:</p>
+ * <pre>npm test</pre>
+ * <p>Or, in a project that uses node-config:</p>
+ * <pre>npm test config</pre>
+ *
+ * @class ConfigTest
+ */
+
+var config;
+vows.describe('Set SubModule Defaults Multiple Times')
+.addBatch({
+  'Library initialization': {
+    topic : function () {
+      // Change the configuration directory for testing
+      process.env.NODE_CONFIG_DIR = __dirname + '/config';
+
+      // Hard-code $NODE_ENV=test for testing
+      process.env.NODE_ENV='test';
+
+      config = requireUncached(__dirname + '/../lib/config');
+
+      return config;
+    },
+    'Config library is available': function() {
+      assert.isObject(config);
+    }
+  },
+})
+.addBatch({
+  'Load the "http-1" submodule with different payloads': {
+    topic : function () {
+      return config.util.setModuleDefaults('http-1', {useAgent: 'lala 42'});
+    },
+    'Config settings "http-1" are set': function(http1) {
+      assert.deepEqual(config.get('http-1'), http1);
+      assert.deepEqual(http1, {
+        useAgent: 'lala 42'
+      });
+    },
+    'Setting submodule defaults for "http-1" again throws an error': function(moduleConfig) {
+      assert.throws(function() {
+        config.util.setModuleDefaults('http-1', {useAgent: 'lala 42', another: 'prop'});
+      }, {
+        name: 'Error',
+        message: 'Submodule "http-1" has already been set'
+      });
+    }
+  }
+})
+.addBatch({
+  'Load the "http-2" submodule with different payloads': {
+    topic : function () {      
+      return config.util.setModuleDefaults('http-2', {obj: {}});
+    },
+    'Config settings "http-2" are set': function(moduleConfig) {
+      assert.deepEqual(config.get('http-2'), moduleConfig);
+      assert.deepEqual(moduleConfig, {
+        obj: {}
+      });
+    },
+    'Setting submodule defaults for "http-2" again throws an error': function(moduleConfig) {
+      assert.throws(function() {
+        config.util.setModuleDefaults('http-2', {obj: {prop: 'this default isn\'t set'}});
+      }, {
+        name: 'Error',
+        message: 'Submodule "http-2" has already been set'
+      });
+    }
+  }
+})
+.addBatch({
+  'Load the "http-3" submodule with different payloads': {
+    topic : function () {
+      return config.util.setModuleDefaults('http-3', {useAgent: 'lala 42'});
+    },
+    'Config settings "http-3" are set': function(moduleConfig) {
+      assert.deepEqual(config.get('http-3'), moduleConfig);
+      assert.deepEqual(moduleConfig, {
+        useAgent: 'lala 42'
+      });
+    },
+    'Setting submodule defaults for "http-3" again throws an error': function(moduleConfig) {
+      assert.throws(function() {
+        config.util.setModuleDefaults('http-3', {useAgent: 'lala 45', another: 'prop'});
+      }, {
+        name: 'Error',
+        message: 'Submodule "http-3" has already been set'
+      });
+    }
+  }
+})
+.addBatch({
+  'Load the "AnotherModule" submodule which has existing local configs': {
+    topic : function () {
+      return config.util.setModuleDefaults('AnotherModule', { parm2: 'value3' });
+    },
+    'Config settings "AnotherModule" are set': function(moduleConfig) {
+      assert.deepEqual(config.get('AnotherModule'), moduleConfig);
+      assert.deepEqual(moduleConfig, {
+        parm2: 'value2', 
+        parm1: 'value1', 
+        parm6: 'value6', 
+        parm8: 'value8', 
+        parm7: 'value7', 
+        parm3: 'value3', 
+        parm2yml: 'value2yml', 
+        parm4: 'value4', 
+        parm5: 'value5', 
+        parm9: 'value9',
+      });
+    },
+    'Setting submodule defaults for "AnotherModule" again throws an error': function(moduleConfig) {
+      assert.throws(function() {
+        config.util.setModuleDefaults('AnotherModule', { parm10: 'value10' });
+      }, {
+        name: 'Error',
+        message: 'Submodule "AnotherModule" has already been set'
+      });
+    },
+    'Get module config overrides defaults': function() {
+      var moduleConfig = config.util.getModuleConfig('AnotherModule', {
+        parm2: 'value3',
+        parm10: 'value10'
+      });
+      assert.deepEqual(moduleConfig, {
+        parm2: 'value3', 
+        parm1: 'value1', 
+        parm6: 'value6', 
+        parm8: 'value8', 
+        parm7: 'value7', 
+        parm3: 'value3', 
+        parm2yml: 'value2yml', 
+        parm4: 'value4', 
+        parm5: 'value5', 
+        parm9: 'value9',
+        parm10: 'value10'
+      });
+      // Get module default value
+      assert.equal(moduleConfig.get('AnotherModule.parm2'), 'value2');
+
+      // Get module config instance values
+      assert.equal(moduleConfig.get('parm2'), 'value3');
+      assert.equal(moduleConfig.get('parm10'), 'value10');
+    },
+    'Get module config for unregisted module': function() {
+      assert.throws(function() {
+        config.util.getModuleConfig('UnregisteredModule', {
+          parm2: 'value3',
+          parm10: 'value10'
+        });
+      }, {
+        name: "Error",
+        message: 'Submodule "UnregisteredModule" defaults has not been set'
+      });
+    }
+  }
+})
+.export(module);


### PR DESCRIPTION
# Goals
* Ensure modules that leverage node-config could be loaded dynamically (well after `config.get` was called) and the applications configuration became immutable (Issue #576 - Late Loading)
* Ensure that a submodule could have multiple instantiated classes which could leverage the modules default/overridden configs (Issue #226)

# Implications (Backwards Compatibility)
* `setModuleDefaults` will now throw an error if it's called more than once for the same `moduleName`.
  * To ensure consistency for each config instance used in the module, we must enforce that the module only register it's defaults once.  Likely in the module's main file.  I don't expect this to be an issue, but would need your feedback.  I don't see how calling this method more than up to now would give predictable behavior.
* `getModuleConfig(moduleName: string, options: object | undefined)` method was added to return a new `Config` instance which merges the provided options into the module's registered default configs and returns a new Config instance.  This method will throw an error if the `setModuleDefaults` was never called for the given module.
* The Wiki page will need some updates to the submodule page to showcase a few approaches.
* Everything else is 100% backwards compatible.  See the added unit tests for new features.  All unit tests are passing.

# Solved Issues
I started this branch to solve the Late Loading portion of #576, but am of the opinion that all acceptance criteria of #576 are met and the ticket can be closed.  I saw an opportunity to improve module configuration support which closes #226 as well.  Let me know if you'd rather me split this into two PRs.

## Issue #572, Late Loading
I found that the setModuleDefaults method would merge the module defaults into the root config object.  This is obviously a problem when my module is dynamically loaded after `config.get` was called and the root config object was immutable and wouldn't accept my module defaults.

1. I decided to create a separate `moduleConfigs` object to store module default configs.  The module defaults will get any existing overrides in the  global config merged in.  Once set on the global `moduleConfigs` object, only that modules entry will be made immutable immediately.
   * By only setting that current module entry as immutable, it allows for additional modules to be added at any time.
2. The `config.get` method was updated to look in the `moduleConfigs` object for keys if they come back undefined on the global config object.

## Allow multiple instances of modules (issue #226)
Please raise issue with any misunderstanding that I have about the current problems regarding multiple instances of modules.  I read through issues #226 and I believe that I've found that adding one new method `getModuleConfig` provides a clean way to create new Config instances which can share the lifecycle of the module instances.

## Issue #572, Submodule config as default
With the `loadFileConfigs` method, It appears that this is already supported.  As a user of this library, I've never found it difficult to simply add the following lines to my submodule's entry point:
```javascript
var config = require('config');
var path = require('path');
const baseConfig = config.util.loadFileConfigs(path.join(__dirname, '..', 'config'));
```
This is hardly a burden and the APIs clearly supports this already.

## Issue #572, Dual purpose
Again, if developers write their modules to load configs from the expected file locations, I don't see why this isn't already supported.  If the ask is to allow modules to access config keys without specifying the root module name, then the approach I provided in the examples may help.  Again, I don't see how this isn't already supported.

# Side effects
## Accessing module default configs
Since the default module settings exist separate from the global config object, then you can access the root module configs from any Config instance.  I see this as a unexpected benefit.  This means that the `getModuleConfig` instances created will allow you to access the module's default configurations.
```javascript
var config = require('config');
config.util.setModuleDefaults('TestModule', { param1: 'value1' });
var moduleConfig = config.util.getModule('TestModule', { param1: "Different Value" });

console.log(moduleConfig.get('param1'));
// Outputs overridden module config "Different Value"

console.log(moduleConfig.get('TestModule.param1'));
// Outputs module default config "value1"
```

# Examples
## Module returns one class
Here's an example module that would provide this behavior.  I added something similar to the unit tests in this PR.
```javascript
var config = require('config');

// Set the module defaults
config.util.setModuleDefaults('TestModule', {
  test: true,
  example: true
});

function TestModule(options) {
  // Get a unique module config based on your defaults with optional override
  this.moduleConfig = config.util.getModuleConfig('TestModule', options);
}

TestModule.prototype.isExample = function() {
  return this.moduleConfig.get('example');
};

module.exports = TestModule;
```

This allows the application to then use the module multiple times.  Each instance of the TestModule class being able to have unique configuration and override as needed.  The trick simply being that each instance would need to manage the retrieved configuration from `getModuleConfig`.

##  Module returns multiple classes with nested
```javascript
var config = require('config');

// Set the module defaults
config.util.setModuleDefaults('TestModule', {
  server: {
    host: 'localhost',
    port: 8080
  },
  client: {
    host: 'localhost',
    port: 8080,
    requestTimeout: 10000
  }
});

function Server(options) {
  // Request module configs, but only override server settings
  var moduleConfig = config.util.getModuleConfig('TestModule', {  server: options || {} });
  this.config = moduleConfig.get('server');
}

function Client(options) {
  // Request module configs, but only override client settings
  var moduleConfig = config.util.getModuleConfig('TestModule', {  client: options || {} });
  this.config = moduleConfig.get('client');
}

module.exports = {
  Server: Server,
  Client: Client
};
```
