### PR TITLE
Make sure that multiple setModuleDefaults calls update the config sources properly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -964,7 +964,8 @@ class LoadInfo {
     }
 
     const path = moduleName.split('.');
-    Util.setPath(moduleDefaults, path, Util.cloneDeep(defaultProperties)); // TODO: This clobber is from the original code, and is a bug
+    const mergedDefaults = Util.extendDeep({}, defaultProperties, Util.getPath(moduleDefaults, path) || {}); // make sources match behavior - #822
+    Util.setPath(moduleDefaults, path, mergedDefaults);
 
     Util.extendDeep(moduleConfig, Util.getPath(this.config, path) || {});
     Util.setPath(this.config, path, moduleConfig);

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -495,7 +495,18 @@ vows.describe('Tests for util functions')
 
         assert.deepEqual(loadInfo.config, { foo: { field1: 'set', field2: 'another' } });
       },
-      'can be called multiple times for the same key': function (loadInfo) {
+      'does not overwrite existing values': function () {
+        let loadInfo = new LoadInfo({});
+
+        loadInfo.addConfig("first", { foo: { field1: 'set'}});
+        loadInfo.setModuleDefaults("foo", { field1: 'override', field2: 'another'});
+
+        assert.deepEqual(loadInfo.config, { foo: { field1: 'set', field2: 'another' } });
+      },
+      'can be called multiple times for the same key': function () {
+        let loadInfo = new LoadInfo({});
+
+        loadInfo.addConfig("first", { foo: { field1: 'set'}});
         loadInfo.setModuleDefaults("foo", { field2: 'another'});
         loadInfo.setModuleDefaults("foo", { field3: 'additional'});
 
@@ -509,6 +520,22 @@ vows.describe('Tests for util functions')
           {
             name: 'Module Defaults',
             parsed: { foo: { field2: 'another' } }
+          }
+        ]);
+      },
+      'getSources() and Config.get() are consistent with each other': function () {
+        let loadInfo = new LoadInfo({});
+
+        loadInfo.setModuleDefaults("foo", { field2: 'another', field4: "1"});
+        loadInfo.setModuleDefaults("foo", { field3: 'additional', field4: "2"});
+
+        // this is probably a bug (#822) but at least the sources and the config now agree with each other.
+        assert.deepEqual(loadInfo.config, { foo: { field2: 'another', field3: 'additional', field4: '1'}});
+
+        assert.deepEqual(loadInfo.getSources(), [
+          {
+            name: 'Module Defaults',
+            parsed: { foo: { field2: 'another', field3: 'additional', field4: '1' } }
           }
         ]);
       }


### PR DESCRIPTION
I don't know if this constitutes a breaking change.  I don't know if anyone is relying on configSources for programmatic behavior.

Abundance of caution says yes.

fixes #827   