### PR TITLE
Default to yaml over js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "coffeescript": "2.2.4",
     "cson": "^3.0.1",
     "hjson": "^1.2.0",
-    "js-yaml": "^3.2.2",
     "properties": "~1.2.1",
     "request": "^2.88.2",
     "semver": "5.3.0",
@@ -38,7 +37,8 @@
     "ts-node": "^3.3.0",
     "typescript": "^2.4.2",
     "underscore": "^1.8.3",
-    "x2js": "^2.0.1"
+    "x2js": "^2.0.1",
+    "yaml": "^2.8.2"
   },
   "repository": {
     "type": "git",

--- a/parser.js
+++ b/parser.js
@@ -11,7 +11,7 @@ const JSON5Module = require('json5');
 const JSON5 = JSON5Module.default || JSON5Module;
 
 var Yaml = null,
-    VisionmediaYaml = null,
+    JSYaml = null,
     Coffee = null,
     Iced = null,
     CSON = null,
@@ -135,34 +135,23 @@ Parser.icedParser = function(filename, content) {
 };
 
 Parser.yamlParser = function(filename, content) {
-  if (!Yaml && !VisionmediaYaml) {
+  if (!Yaml && !JSYaml) {
     // Lazy loading
     try {
-      // Try to load the better js-yaml module
-      Yaml = require(JS_YAML_DEP);
-    }
-    catch (e) {
+      Yaml = require(YAML_DEP);
+    } catch (e) {
       try {
-        // If it doesn't exist, load the fallback visionmedia yaml module.
-        VisionmediaYaml = require(YAML_DEP);
-      }
-      catch (e) { }
+        JSYaml = require(JS_YAML_DEP);
+      } catch (e) {}
     }
   }
+
   if (Yaml) {
-    return Yaml.load(content);
-  }
-  else if (VisionmediaYaml) {
-    // The yaml library doesn't like strings that have newlines but don't
-    // end in a newline: https://github.com/visionmedia/js-yaml/issues/issue/13
-    content += '\n';
-    if (typeof VisionmediaYaml.eval === 'function') {
-      return VisionmediaYaml.eval(Parser.stripYamlComments(content));
-    }
-    return VisionmediaYaml.parse(Parser.stripYamlComments(content));
-  }
-  else {
-    console.error('No YAML parser loaded.  Suggest adding js-yaml dependency to your package.json file.')
+    return Yaml.parse(content);
+  } else if (JSYaml) {
+    return JSYaml.load(content);
+  } else {
+    console.error('No YAML parser loaded.  Suggest adding yaml dependency to your package.json file.')
   }
 };
 


### PR DESCRIPTION
js-yaml is mostly dead although it did get a CVE patch to address the issue that got it put onto a watch list.

'yaml' is no longer TJ's project but is a completely different repo that is being actively maintained.

addresses #851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal YAML parsing logic and updated related dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->