### PR TITLE
Prevent extension when calling makeImmutable(), and add pinning tests

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,6 @@ const { Util, Load } = require('./util.js');
 const Path = require('path');
 
 const DEFAULT_CLONE_DEPTH = 20;
-let checkMutability = true;      // Check for mutability/immutability on first get
 
 /**
  * <p>Application Configurations</p>
@@ -132,11 +131,10 @@ Config.prototype.get = function(property) {
   }
 
   // Make configurations immutable after first get (unless disabled)
-  if (checkMutability) {
+  if (Object.isExtensible(config)) {
     if (!FIRST_LOAD.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
       util.makeImmutable(config);
     }
-    checkMutability = false;
   }
   const t = this;
   const value = Util.getPath(t, property);
@@ -220,13 +218,6 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
     Util.extendDeep(existing, moduleConfig);
   }
 
-  // reset the mutability check for "config.get" method.
-  // we are not making t[moduleName] immutable immediately,
-  // since there might be more modifications before the first config.get
-  if (!FIRST_LOAD.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-    checkMutability = true;
-  }
-
   // Attach handlers & watchers onto the module config object
   return util.attachProtoDeep(Util.getPath(t, path));
 };
@@ -237,15 +228,8 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
  * <p>
  * If the specified property is an object, all attributes of that object are
  * made immutable, including properties of contained objects, recursively.
- * If a property name isn't supplied, all properties of the object are made
- * immutable.
- * </p>
- * <p>
- *
- * </p>
- * <p>
- * New properties can be added to the object and those properties will not be
- * immutable unless this method is called on those new properties.
+ * If a property name isn't supplied, the object and all of its properties
+ * are made immutable.
  * </p>
  * <p>
  * This operation cannot be undone.
@@ -261,7 +245,7 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
  * @method makeImmutable
  * @param object {Object} - The object to specify immutable properties for
  * @param [property] {string | [string]} - The name of the property (or array of names) to make immutable.
- *        If not provided, all owned properties of the object are made immutable.
+ *        If not provided, the entire object is marked immutable.
  * @param [value] {* | [*]} - Property value (or array of values) to set
  *        the property to before making immutable. Only used when setting a single
  *        property. Retained for backward compatibility.
@@ -271,7 +255,7 @@ util.makeImmutable = function(object, property, value) {
   if (Buffer.isBuffer(object)) {
     return object;
   }
-  let properties = null;
+
 
   // Backwards compatibility mode where property/value can be specified
   if (typeof property === 'string') {
@@ -282,11 +266,12 @@ util.makeImmutable = function(object, property, value) {
     });
   }
 
-  // Get the list of properties to work with
+  let partial = false;
+  let properties = null;// Get the list of properties to work with
   if (Array.isArray(property)) {
     properties = property;
-  }
-  else {
+    partial = true;
+  } else {
     properties = Object.keys(object);
   }
 
@@ -354,11 +339,13 @@ util.makeImmutable = function(object, property, value) {
           configurable: false
         });
       }
-
-      // Ensure new properties can not be added, as per:
-      // https://github.com/lorenwest/node-config/issues/505
-      Object.preventExtensions(object[propertyName])
     }
+  }
+
+  if (!partial) {  // Ensure new properties can not be added, as per:
+    // https://github.com/lorenwest/node-config/issues/505
+    // https://github.com/lorenwest/node-config/issues/865
+    Object.preventExtensions(object)
   }
 
   return object;

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -99,6 +99,18 @@ describe('Test suite for node-config', function() {
         /Can not update runtime configuration property: "arr1"\. Configuration objects are immutable unless ALLOW_CONFIG_MUTATIONS is set\./
       )
     });
+
+    it('reverse tree walk also prevents mutation after second get()', function() {
+      config.TestModule.get('parm1');
+      config.get('Customers')
+
+      assert.throws(
+        function() {
+          config.Customers.dbHost = [ 'bad value' ];
+        },
+        /Can not update runtime configuration property: "dbHost"\. Configuration objects are immutable unless ALLOW_CONFIG_MUTATIONS is set\./
+      )
+    });
   });
 
   describe('Configurations from the $NODE_CONFIG environment variable', function() {
@@ -152,6 +164,13 @@ describe('Test suite for node-config', function() {
       assert.throws(() => config.TestModule.parm1 = "setToThis",
         /Cannot assign to read only property/);
       assert.strictEqual(config.TestModule.parm1, "value1");
+    });
+
+    it('Correctly unable to add new fields to an immutable configuration', function() {
+      config.util.makeImmutable(config.TestModule);
+
+      assert.throws(() => config.TestModule.newField = "setToThis",
+        /Cannot add property newField, object is not extensible/);
     });
   });
 


### PR DESCRIPTION
Ask JavaScript if the object is mutable instead of trying to track state

Fix for both bugs in #865, and makes #864 more agreeable to honoring the immutability contract.

**Note** while this PR is marked as a breaking change, absolutely none of our existing tests failed with this change,
meaning we have documented behavior that we do not test for.

Looking into the commit history, the contrary comment in the JSDoc dates to a time when this function was about
eight lines long and had none of the other many, many additions to enforce immutability. I propose that this is not actually a useful feature anymore. But I will mark this as 4.4 which will have several other breaking changes, to leave 4.3 more or less in peace. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated immutability behavior to use a runtime extensibility check and added partial-mode so selected top-level properties can remain extensible while nested settings stay immutable.

* **Tests**
  * Added tests ensuring immutability holds after sequential accesses and that adding new properties to an immutable configuration is prevented.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->