### PR TITLE
Restore config.util.getEnv()

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -547,6 +547,22 @@ util.attachProtoDeep = function(toObject, depth) {
 };
 
 /**
+ * <p>Get a Config Environment Variable Value</p>
+ *
+ * <p>
+ * This method returns the value of the specified config environment variable,
+ * including any defaults or overrides.
+ * </p>
+ *
+ * @method getEnv
+ * @param varName {String} The environment variable name
+ * @return {String} The value of the environment variable
+ */
+util.getEnv = function (varName) {
+  return FIRST_LOAD.getEnv(varName);
+}
+
+/**
  * Returns a new deep copy of the current config object, or any part of the config if provided.
  *
  * @param {Object} config The part of the config to copy and serialize. Omit this argument to return the entire config.

--- a/test/util.js
+++ b/test/util.js
@@ -4,10 +4,27 @@ const path = require('path');
 const requireUncached = require('./_utils/requireUncached');
 const { describe, it, beforeEach } = require('node:test');
 const assert = require('assert');
-const config = require('../lib/config');
-const initParam = config.util.initParam;
 
 describe('Tests for config util functions', function() {
+  describe('Tests for util.getEnv()', function() {
+    let util;
+
+    beforeEach(function () {
+      // Change the configuration directory for testing
+      process.env.NODE_CONFIG_DIR = __dirname + '/config';
+
+      // Hard-code $NODE_CONFIG_ENV=test for testing
+      delete process.env.NODE_APP_INSTANCE;
+      process.env.NODE_CONFIG_ENV = 'test';
+
+      util = requireUncached(__dirname + '/../lib/config').util;
+    });
+
+    it('values used in initialization are reflected in getEnv()', function () {
+      assert.strictEqual(util.getEnv('NODE_CONFIG_ENV'), 'test');
+    });
+  });
+
   describe('Tests for util.loadFileConfigs', function () {
     let util;
 


### PR DESCRIPTION
The env object on Load is not accessible to users of the library. This function should not have been marked as deprecated without a suitable replacement.

To resolve #871 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new utility method for retrieving environment variables.

* **Tests**
  * Added test coverage for the environment variable retrieval functionality with proper environment setup and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->