### PR TITLE
Relocate parts of makeImmutable to lib/util.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -275,6 +275,7 @@ class ConfigUtils {
    * </pre>
    *
    * @method makeImmutable
+   * @deprecated see Util.makeImmutable()
    * @param {any} object - The object to specify immutable properties for
    * @param {string | string[]=} property - The name of the property (or array of names) to make immutable.
    *        If not provided, the entire object is marked immutable.
@@ -284,13 +285,52 @@ class ConfigUtils {
    * @return {any} - The original object is returned - for chaining.
    */
   makeImmutable(object, property, value) {
-    if (Buffer.isBuffer(object)) {
-      return object;
-    } else if (object === undefined) {
-      object = this.#config;
+    if (object === undefined) {
+      return Util.makeImmutable(this.#config);
     }
 
+    Util.errorOnce("MAKE_IMMUTABLE", "`config.util.makeImmutable(obj)` is deprecated, and will not be supported in 5.0");
 
+    if (property !== undefined) {
+      return this.makeImmutablePartial(object, property, value);
+    } else {
+      return Util.makeImmutable(object);
+    }
+  }
+
+  /**
+   * <p>Make a javascript object property immutable (assuring it cannot be changed
+   * from the current value).</p>
+   * <p>
+   * If the specified property is an object, all attributes of that object are
+   * made immutable, including properties of contained objects, recursively.
+   * If a property name isn't supplied, the object and all of its properties
+   * are made immutable.
+   * </p>
+   * <p>
+   * This operation cannot be undone.
+   * </p>
+   *
+   * <p>Example:</p>
+   * <pre>
+   *   const config = require('config');
+   *   const myObject = {hello:'world'};
+   *   config.util.makeImmutable(myObject);
+   * </pre>
+   *
+   * @method makeImmutable
+   * @protected
+   * @deprecated - partial immutability will no longer be supported by this project
+   * @param object {Object} - The object to specify immutable properties for
+   * @param property {string | [string]} - The name of the property (or array of names) to make immutable.
+   *        If not provided, the entire object is marked immutable.
+   * @param [value] {* | [*]} - Property value (or array of values) to set
+   *        the property to before making immutable. Only used when setting a single
+   *        property. Retained for backward compatibility.
+   * @return object {Object} - The original object is returned - for chaining.
+   */
+  makeImmutablePartial(object, property, value) {
+    Util.errorOnce("PARTIAL_IMMUTABLE", "`makeImmutable(object, propName, value)` is deprecated and will not be supported in 5.0");
     // Backwards compatibility mode where property/value can be specified
     if (typeof property === 'string') {
       return Object.defineProperty(object, property, {
@@ -300,16 +340,7 @@ class ConfigUtils {
       });
     }
 
-    let partial = false;
-    let properties;
-
-    // Get the list of properties to work with
-    if (Array.isArray(property)) {
-      properties = property;
-      partial = true;
-    } else {
-      properties = Object.keys(object);
-    }
+    let properties = property;
 
     // Process each property
     for (let i = 0; i < properties.length; i++) {
@@ -326,7 +357,7 @@ class ConfigUtils {
         // Ensure object items of this array are also immutable.
         value.forEach((item, index) => {
           if (Util.isObject(item) || Array.isArray(item)) {
-            this.makeImmutable(item);
+            Util.makeImmutable(item);
           }
         });
 
@@ -338,7 +369,7 @@ class ConfigUtils {
         if (Util.isObject(value)) {
           // Create a proxy, to capture user updates of configuration options, and throw an exception for awareness, as per:
           // https://github.com/lorenwest/node-config/issues/514
-          value = new Proxy(this.makeImmutable(value), {
+          value = new Proxy(Util.makeImmutable(value), {
             get(target, property, receiver) {
               // Config's own defined prototype properties and methods (e.g., `get`, `has`, etc.)
               const ownProps = [
@@ -382,11 +413,9 @@ class ConfigUtils {
       }
     }
 
-    if (!partial) {  // Ensure new properties can not be added, as per:
-      // https://github.com/lorenwest/node-config/issues/505
-      // https://github.com/lorenwest/node-config/issues/865
-      Object.preventExtensions(object)
-    }
+    // https://github.com/lorenwest/node-config/issues/505
+    // https://github.com/lorenwest/node-config/issues/865
+    Object.preventExtensions(object)
 
     return object;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,6 +10,7 @@ const { resolveAsyncConfigs } = require('../async');
 const Path = require('path');
 const FileSystem = require('fs');
 const OS = require("os");
+const {RawConfig} = require("../raw");
 
 const DEFAULT_CONFIG_DIR = Path.join( process.cwd(), 'config');
 const SEEN_ERRORS = {};
@@ -112,6 +113,98 @@ class Util {
         configurable: true
       });
     }
+
+    return object;
+  }
+
+  /**
+   * Make a javascript object immutable (assuring it cannot be changed from the current value)
+   *
+   * All attributes of that object are made immutable, including properties of contained
+   * objects, recursively.
+   *
+   * This operation cannot be undone.
+   *
+   * <p>Example:</p>
+   * <pre>
+   *   const config = require('config');
+   *   const myObject = {hello:'world'};
+   *   Util.makeImmutable(myObject);
+   * </pre>
+   *
+   * @method makeImmutable
+   * @param object {Object} - The object to freeze
+   * @return object {Object} - The original object is returned - for chaining.
+   */
+  static makeImmutable(object) {
+    if (Buffer.isBuffer(object)) {
+      return object;
+    }
+
+    for (let propertyName of Object.keys(object)) {
+      let value = object[propertyName];
+
+      if (value instanceof RawConfig) {
+        Object.defineProperty(object, propertyName, {
+          value: value.resolve(),
+          writable: false,
+          configurable: false
+        });
+      } else if (Array.isArray(value)) {
+        // Ensure object items of this array are also immutable.
+        for (let item of value) {
+          if (this.isObject(item) || Array.isArray(item)) {
+            this.makeImmutable(item);
+          }
+        }
+
+        Object.defineProperty(object, propertyName, {
+          value: Object.freeze(value)
+        });
+      } else {
+        // Call recursively if an object.
+        if (this.isObject(value)) {
+          // Create a proxy, to capture user updates of configuration options, and throw an exception for awareness, as per:
+          // https://github.com/lorenwest/node-config/issues/514
+          value = new Proxy(this.makeImmutable(value), {
+            get(target, property, receiver) {
+              // Bypass proxy receiver for properties directly on the target (e.g., RegExp.prototype.source)
+              // or properties that are not functions to prevent errors related to internal object methods.
+              if (target.hasOwnProperty(property) || (property in target && typeof target[property] !== 'function')) {
+                return Reflect.get(target, property);
+              }
+
+              // Otherwise, use the proxy receiver to handle the property access
+              const ref = Reflect.get(target, property, receiver);
+
+              // Binds the method's `this` context to the target object (e.g., Date.prototype.toISOString)
+              // to ensure it behaves correctly when called on the proxy.
+              if (typeof ref === 'function') {
+                return ref.bind(target);
+              }
+              return ref;
+            },
+            set(target, name) {
+              const message = (Reflect.has(target, name) ? 'update' : 'add');
+              // Notify the user.
+              throw Error(`Can not ${message} runtime configuration property: "${name}". Configuration objects are immutable unless ALLOW_CONFIG_MUTATIONS is set.`)
+            }
+          });
+        }
+
+        // Check if property already has writable: false and configurable: false
+        const currentDescriptor = Object.getOwnPropertyDescriptor(object, propertyName);
+        if (!currentDescriptor || currentDescriptor.writable !== false || currentDescriptor.configurable !== false) {
+          Object.defineProperty(object, propertyName, {
+            value: value,
+            writable: false,
+            configurable: false
+          });
+        }
+      }
+    }
+
+    Object.preventExtensions(object)
 
     return object;
   }

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -118,6 +118,75 @@ describe('Tests for util functions', function () {
     });
   });
 
+  describe('Util.makeImmutable()', function() {
+    let object;
+
+    beforeEach(function () {
+      object = {
+        item1: 23,
+        subObject: {
+          item2: "hello",
+          entries: [ { a: "b"}, { b: "c", c: { d: "e" } }],
+        }
+      };
+    });
+
+    it('method is available', function () {
+      assert.strictEqual(typeof util.makeImmutable, 'function');
+    });
+
+    // This not working is a bug #865
+    // it('prevents changes to configuration', function() {
+    //   util.makeImmutable(object);
+    //
+    //   assert.throws(() => object.item1 = 27,
+    //     /Cannot assign to read only property/);
+    //   assert.strictEqual(object.item1, 23);
+    // });
+
+    it('prevents changes to children', function() {
+      util.makeImmutable(object);
+
+      assert.throws(() => object.subObject.item2 = 'goodbye',
+        /Can not update runtime configuration property: "item2"/);
+      assert.strictEqual(object.subObject.item2, 'hello');
+    });
+
+    it('prevents addition of new fields', function() {
+      util.makeImmutable(object);
+
+      assert.throws(() => object.subObject.newField = "setToThis",
+        /Can not add runtime configuration property: "newField"/);
+    });
+
+    // This is the same bug #865
+    // it('objects in arrays should be immutable', function () {
+    //   util.makeImmutable(object);
+    //
+    //   const firstTask = object.subObject.entries[0];
+    //   assert.throws(function () {
+    //     firstTask.a = "a"; // We don't make the object itself immutable, only its children
+    //   }, /Can not update runtime configuration property/);
+    // });
+
+    it('objects in arrays should be immutable', function () {
+      util.makeImmutable(object);
+
+      const secondTask = object.subObject.entries[1];
+      assert.throws(function () {
+        secondTask.c.d = "a";
+      }, /Can not update runtime configuration property/);
+    });
+
+    it('Should not throw error when called twice on same object', function() {
+      // First call
+      util.makeImmutable(object);
+
+      util.makeImmutable(object);
+      util.makeImmutable({ a: object.subObject.entries });
+    });
+  });
+
   describe('Util.getOption()', function() {
     let options;
 


### PR DESCRIPTION
This PR builds on top of #864 

The second commit relocates all but the selective immutability code and puts it into Util. 

A subsequent PR will close a substantial bug in how makeImmutable works. IMO, #865 is a bug, so it will not receive a warning or a year grace period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive utility method for object immutability with recursive support for nested objects and arrays.
  * Introduced method for selective property-level immutability.

* **Deprecations**
  * Existing immutability method marked as deprecated; users should migrate to new utility method.

* **Tests**
  * Added test coverage for immutability functionality including nested structures and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->