### PR TITLE
Rework raw.js to function like the new defer mechanism.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -8,8 +8,7 @@
 /** @typedef {import('./util').Load} Load */
 /** @typedef {import('./util').LoadOptions} LoadOptions */
 /** @typedef {typeof import('./../parser')} Parser */
-const RawConfig = require('../raw').RawConfig;
-const { Util, Load } = require('./util.js');
+const { Util, Load, RawConfig } = require('./util.js');
 const Path = require('path');
 
 const DEFAULT_CLONE_DEPTH = 20;

--- a/lib/util.js
+++ b/lib/util.js
@@ -18,6 +18,7 @@ const SEEN_ERRORS = {};
  * @typedef {Object} BootstrapCallbackContext
  * @property {Util} util
  * @property {deferConfig} defer
+ * @property {RawConfig.raw} raw
  */
 
 /**
@@ -429,8 +430,6 @@ class Util {
     const allChildren = [];
     const util = this;
 
-    const useBuffer = typeof Buffer !== 'undefined';
-
     if (typeof circular === 'undefined')
       circular = true;
 
@@ -458,10 +457,12 @@ class Util {
         if (parent.lastIndex) child.lastIndex = parent.lastIndex;
       } else if (parent instanceof Date) {
         child = new Date(parent.getTime());
-      } else if (useBuffer && Buffer.isBuffer(parent)) {
+      } else if (Buffer.isBuffer(parent)) {
         child = Buffer.alloc(parent.length);
         parent.copy(child);
         return child;
+      } else if (parent instanceof RawConfig) {
+        child = parent;
       } else {
         if (typeof prototype === 'undefined') child = Object.create(Object.getPrototypeOf(parent));
         else child = Object.create(prototype);
@@ -650,19 +651,19 @@ class Util {
         if (mergeFrom[prop] instanceof Date) {
           mergeInto[prop] = mergeFrom[prop];
         }
-        if (mergeFrom[prop] instanceof RegExp) {
+
+        if ((mergeFrom[prop] instanceof RegExp) ||
+            (mergeFrom[prop] instanceof RawConfig)) {
           mergeInto[prop] = mergeFrom[prop];
         } else if (Util.isObject(mergeInto[prop]) && Util.isObject(mergeFrom[prop]) && !isDeferredFunc) {
           Util.extendDeep(mergeInto[prop], mergeFrom[prop], depth - 1);
         } else if (Util.isPromise(mergeFrom[prop])) {
           mergeInto[prop] = mergeFrom[prop];
-        }
-        // Copy recursively if the mergeFrom element is an object (or array or fn)
-        else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object') {
+        } else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object') {
+          // Copy recursively if the mergeFrom element is an object (or array or fn)
           mergeInto[prop] = Util.cloneDeep(mergeFrom[prop], depth - 1);
-        }
-        // Copy property descriptor otherwise, preserving accessors
-        else if (Object.getOwnPropertyDescriptor(Object(mergeFrom), prop)) {
+        } else if (Object.getOwnPropertyDescriptor(Object(mergeFrom), prop)) {
+          // Copy property descriptor otherwise, preserving accessors
           Object.defineProperty(mergeInto, prop, Object.getOwnPropertyDescriptor(Object(mergeFrom), prop));
         } else if (mergeInto[prop] !== mergeFrom[prop]) {
           mergeInto[prop] = mergeFrom[prop];
@@ -1040,7 +1041,7 @@ class Load {
       /** @type bootstrapCallback */
       let fn = configObject;
 
-      configObject = fn({ defer: deferConfig, util: Util });
+      configObject = fn({ defer: deferConfig, util: Util, raw: RawConfig.raw });
     }
 
     if (convert) {
@@ -1076,8 +1077,8 @@ class Load {
 
   /**
    * Return the report of where the sources for this load operation came from
- * @returns {ConfigSource[]}
- */
+   * @returns {ConfigSource[]}
+   */
   getSources() {
     return (this.sources ?? []).slice();
   }
@@ -1295,6 +1296,32 @@ class Load {
   }
 }
 
+/**
+ * This is meant to wrap configuration objects that should be left as is,
+ * meaning that the object or its prototype will not be modified in any way
+ */
+class RawConfig {
+  #rawObject = undefined;
+
+  constructor(data) {
+    this.#rawObject = data;
+  }
+
+  resolve() {
+    return this.#rawObject;
+  }
+
+  /**
+   * create a RawConfig
+   * @param rawObject {Object} properties we don't want to have manipulated by node-config
+   * @returns {RawConfig}
+   */
+  static raw(rawObject) {
+    return new RawConfig(rawObject);
+  }
+}
+
+
 // Helper functions shared across object members
 function _toAbsolutePath (configDir) {
   if (configDir.indexOf('.') === 0) {
@@ -1320,4 +1347,4 @@ function _loadParser(name, dir) {
   }
 }
 
-module.exports = { Util, Load };
+module.exports = { Util, Load, RawConfig };

--- a/raw.js
+++ b/raw.js
@@ -1,20 +1,16 @@
-/**
- * This is meant to wrap configuration objects that should be left as is,
- * meaning that the object or its prototype will not be modified in any way
- * @constructor
- */
-function RawConfig () {
-}
+const { Util, RawConfig } = require('./lib/util')
 
 /**
  * @param {any} rawObj
  * @returns {RawConfig & { resolve: () => any }}
  */
 function raw(rawObj) {
-  var obj = Object.create(RawConfig.prototype);
-  obj.resolve = function () { return rawObj; }
-  return obj;
+  Util.errorOnce('RAW_CONFIG', 'node-config now supports config file callbacks in place of raw(), which is deprecated.');
+
+  return RawConfig.raw(rawObj);
 }
 
+/** @deprecated please use callback function */
 module.exports.RawConfig = RawConfig;
+/** @deprecated please use callback function */
 module.exports.raw = raw;


### PR DESCRIPTION
This should be the last part of the config API that blocks ESM usage.

addresses #878 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a RawConfig utility to mark/preserve raw objects through config processing.
  * Executable config bootstrap callbacks now receive a raw entry in their context.

* **Deprecations**
  * Legacy raw() helper deprecated — now delegates to RawConfig and emits a runtime deprecation warning.

* **Exports**
  * RawConfig is exported from the primary utility surface (previous export path consolidated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->