### PR TITLE
Fix badges and Release Notes link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 Configure your Node.js Applications
 ===================================
 
-[![NPM](https://nodei.co/npm/config.svg?downloads=true&downloadRank=true)](https://nodei.co/npm/config/)&nbsp;&nbsp;
-[![Build Status](https://secure.travis-ci.org/node-config/node-config.svg?branch=master)](https://travis-ci.org/lorenwest/node-config)&nbsp;&nbsp;
-[release notes](https://github.com/node-config/node-config/blob/master/History.md)
+[![npm package](https://img.shields.io/npm/v/config)](https://www.npmjs.com/package/config)
+[![Downloads](https://img.shields.io/npm/dt/config)](https://www.npmjs.com/package/config)
+[![Issues](https://img.shields.io/github/issues/node-config/node-config)](https://github.com/node-config/node-config/issues)
+
+[Release Notes](https://github.com/node-config/node-config/releases)
 
 Introduction
 ------------


### PR DESCRIPTION
Travis CI is no more and the releases link still points to the old page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced README header badges with new shields showing npm package, download counts, issue status, and a Release Notes link. Cosmetic update only—no runtime or functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->