### PR TITLE
Matrix builds and separate benchmarks from ci run.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,17 +14,41 @@ jobs:
   Unit-Tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    strategy:
+      matrix:
+        node-version: [ 22.x, 24.x ]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install Dependencies
         run: npm install
 
       - name: Run Tests
         run: npm run ci
+  Benchmarks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Run Benchmarks
+        run: npm run benchmarks
+

--- a/package.json
+++ b/package.json
@@ -100,9 +100,10 @@
   "scripts": {
     "build:types": "tsc -p tsconfig.json",
     "checkTypes": "npx -y @arethetypeswrong/cli --pack .",
+    "types": "npm run build:types && npm run checkTypes",
     "prepublishOnly": "npm run build:types",
-    "ci": "npm run test && npm run benchmarks",
-    "test": "NODE_OPTIONS='--no-experimental-strip-types' c8 node --test",
+    "ci": "npm run types && npm run test",
+    "test": "c8 node --no-experimental-strip-types --test",
     "benchmarks": "node --allow-natives-syntax --expose-gc benchmarks/index.js"
   }
 }


### PR DESCRIPTION
I'm missing the benchmark results in the PR listing, and also with recent changes we should absolutely be making sure the code still runs properly on node 20 and 22.

So, this change runs the type checking and unit tests on 20, 22, and 24, but as a separate step runs the benchmarks as a separate task (on node 24) for better visibility. 

This is closer to the way some other projects I work with function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs unit tests on Node.js 22.x and 24.x with dependency caching.
  * CI Node setup action updated to a newer version.
  * Added a separate benchmarks job to the workflow.
  * Pipeline now performs a dedicated type-check step before running tests.
  * Test invocation simplified for more reliable test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->