### PR TITLE
Improve ergonomics of setModuleDefaults/Load.scan()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1095,7 +1095,9 @@ class Load {
   /**
    * scan and load config files in the same manner that config.js does
    *
+   * @see ConfigUtils.setModuleDefaults()
    * @param {{name: string, config: any}[]=} additional additional values to populate (usually from NODE_CONFIG)
+   * @returns {object} - config data
    */
   scan(additional) {
     Util.loadFileConfigs(this);
@@ -1110,6 +1112,8 @@ class Load {
     this.loadCustomEnvVars();
 
     Util.resolveDeferredConfigs(this.config);
+
+    return this.config;
   }
 
   /**

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -1712,6 +1712,13 @@ describe('Tests for util functions', function () {
 
       assert.deepEqual(load.getSources(), []);
     });
+
+    it('returns the resolved data', function() {
+      let load = new Load({configDir: import.meta.dirname + '/config', skipConfigSources: true});
+      let actual = load.scan();
+
+      assert.strictEqual(actual, load.config);
+    });
   });
 
   describe('Load.clone()', function() {


### PR DESCRIPTION
Fixes #901

This should simplify the setup code for moduleDefaults, which I'll update in the docs.

```
let load = new Load({...});
config.util.setModuleDefaults("myModule", load.scan());
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration loading method now returns the resolved configuration object, enabling direct access to configuration data after processing.

* **Tests**
  * Added test coverage to verify correct return of resolved configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->