### PR TITLE
fix: use anchored regex for NODE_ENV file matching (closes #867)

### DIFF
--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -603,9 +603,11 @@ class ConfigUtils {
     });
 
     load.options.nodeEnv.forEach(function (env) {
-      // Throw an exception if there's no explicit config file for NODE_ENV
+      // Throw an exception if there's no explicit config file for NODE_ENV.
+      // Use an anchored regex to avoid false positives (e.g. env='test' matching 'contest.json').
+      const envPattern = new RegExp(`^${env}[.-]`);
       const anyFilesMatchEnv = sourceFilenames.some(function (filename) {
-        return filename.match(env);
+        return envPattern.test(filename);
       });
       // development is special-cased because it's the default value
       if (env && (env !== 'development') && !anyFilesMatchEnv) {

--- a/test/6-config/contest.json
+++ b/test/6-config/contest.json
@@ -1,0 +1,3 @@
+{
+  "siteTitle": "contest config — should not match NODE_ENV=test"
+}

--- a/test/6-strict-mode.js
+++ b/test/6-strict-mode.js
@@ -59,6 +59,13 @@ describe('Tests for strict mode', function() {
                      +"See https://github.com/node-config/node-config/wiki/Strict-Mode",
   }));
 
+  describe("NODE_ENV=test throws exception when only 'contest.json' exists (inexact match regression)", _expectException({
+    NODE_ENV         : 'test',
+    APP_INSTANCE     : 'valid-instance',
+    exceptionMessage : "FATAL: NODE_ENV value of 'test' did not match any deployment config file names. "
+                     + "See https://github.com/node-config/node-config/wiki/Strict-Mode",
+  }));
+
   describe("Specifying NODE_CONFIG_ENV=production,cloud with no cloud file throws an exception with appropriate wording", _expectException({
     NODE_CONFIG_ENV  : 'cloud',
     APP_INSTANCE     : 'valid-instance',
@@ -86,6 +93,8 @@ function _expectException (opts) {
 
       if (!!opts.NODE_CONFIG_ENV) {
         process.env.NODE_CONFIG_ENV       = opts.NODE_CONFIG_ENV;
+      } else {
+        delete process.env.NODE_CONFIG_ENV;
       }
 
       delete process.env.NODE_CONFIG;


### PR DESCRIPTION
## Problem

The current strictness check uses `filename.match(env)` which performs a substring match. This means `NODE_ENV=test` would falsely match a file named `contest.json`, suppressing the expected warning or exception in strict mode.

## Fix

Replace the substring match with an anchored regular expression:

```js
const envPattern = new RegExp(`^${env}[.-]`);
const anyFilesMatchEnv = sourceFilenames.some(function (filename) {
  return envPattern.test(filename);
});
```

The pattern `^<env>[.-]` ensures:
- The env name appears at the **start** of the filename
- It is immediately followed by a separator (`.` for extension, `-` for instance suffix)
- Partial matches like `contest.json` for `env=test` are correctly rejected

## Tests

- Added `test/6-config/contest.json` as a fixture to represent the false-positive scenario
- Added a regression test: `NODE_ENV=test` in strict mode must throw even when only `contest.json` exists
- Fixed environment state leak in the test helper: `NODE_CONFIG_ENV` is now cleared between suites when not explicitly set, preventing interference between test cases
- All 319 existing tests continue to pass

Fixes #867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration validation matching logic to be more precise and prevent unintended file matches in deployment scenarios.

* **Tests**
  * Added test coverage for configuration validation edge cases to verify correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->